### PR TITLE
retain ReadOnlyDictionary reference instead of recreating instance on each property get

### DIFF
--- a/Sources/Accord.MachineLearning/BagOfWords.cs
+++ b/Sources/Accord.MachineLearning/BagOfWords.cs
@@ -67,7 +67,10 @@ namespace Accord.MachineLearning
     {
 
         private Dictionary<string, int> stringToCode;
+        private ReadOnlyDictionary<string, int> readOnlyStringToCode;
+
         private Dictionary<int, string> codeToString;
+        private ReadOnlyDictionary<int, string> readOnlyCodeToString;
 
 
         /// <summary>
@@ -83,7 +86,7 @@ namespace Accord.MachineLearning
         /// 
         public ReadOnlyDictionary<string, int> StringToCode
         {
-            get { return new ReadOnlyDictionary<string, int>(stringToCode); }
+            get { return readOnlyStringToCode; }
         }
 
         /// <summary>
@@ -93,7 +96,7 @@ namespace Accord.MachineLearning
         /// 
         public ReadOnlyDictionary<int, string> CodeToString
         {
-            get { return new ReadOnlyDictionary<int, string>(codeToString); }
+            get { return readOnlyCodeToString; }
         }
 
         /// <summary>
@@ -144,7 +147,10 @@ namespace Accord.MachineLearning
         private void initialize(string[][] texts)
         {
             stringToCode = new Dictionary<string, int>();
+            readOnlyStringToCode = new ReadOnlyDictionary<string, int>(stringToCode);
+
             codeToString = new Dictionary<int, string>();
+            readOnlyCodeToString = new ReadOnlyDictionary<int, string>(codeToString);
 
             MaximumOccurance = 1;
 

--- a/Sources/Accord.Math/Optimization/NonlinearObjectiveFunction.cs
+++ b/Sources/Accord.Math/Optimization/NonlinearObjectiveFunction.cs
@@ -25,8 +25,6 @@ namespace Accord.Math.Optimization
     using System;
     using System.Collections.Generic;
     using System.Linq.Expressions;
-    using System.Text.RegularExpressions;
-    using System.Text;
 
     /// <summary>
     ///   Quadratic objective function.
@@ -36,7 +34,10 @@ namespace Accord.Math.Optimization
     {
 
         private Dictionary<string, int> variables;
+        private readonly ReadOnlyDictionary<string, int> readOnlyVariables;
+
         private Dictionary<int, string> indices;
+        private ReadOnlyDictionary<int, string> readOnlyIndices;
 
         /// <summary>
         ///   Gets input variable's labels for the function.
@@ -44,7 +45,7 @@ namespace Accord.Math.Optimization
         /// 
         public IDictionary<string, int> Variables
         {
-            get { return new ReadOnlyDictionary<string, int>(variables); }
+            get { return readOnlyVariables; }
         }
 
         /// <summary>
@@ -53,7 +54,7 @@ namespace Accord.Math.Optimization
         /// 
         public IDictionary<int, string> Indices
         {
-            get { return new ReadOnlyDictionary<int, string>(indices); }
+            get { return readOnlyIndices; }
         }
 
         /// <summary>
@@ -94,7 +95,11 @@ namespace Accord.Math.Optimization
             this.Gradient = gradient;
 
             variables = new Dictionary<string, int>();
+            readOnlyVariables = new ReadOnlyDictionary<string, int>(variables);
+
             indices = new Dictionary<int, string>();
+            readOnlyIndices = new ReadOnlyDictionary<int, string>(indices);
+
             for (int i = 0; i < numberOfVariables; i++)
             {
                 string name = "x" + i;
@@ -118,7 +123,10 @@ namespace Accord.Math.Optimization
             Expression<Func<double[]>> gradient = null)
         {
             variables = new Dictionary<string, int>();
+            readOnlyVariables = new ReadOnlyDictionary<string, int>(variables);
+
             indices = new Dictionary<int, string>();
+            readOnlyIndices = new ReadOnlyDictionary<int, string>(indices);
 
             SortedSet<string> list = new SortedSet<string>();
             ExpressionParser.Parse(list, function.Body);


### PR DESCRIPTION
ReadOnlyDictionary is only a wrapper around an existing dictionary so you can retain the reference instead of recreating new instances on each property get.

This change avoids a (minor) performance bottleneck if a user queries the properties in a loop and is not aware of the inner implementation.
