### PR TITLE
Added support for Format32bppRgb to IntegralImage2.

### DIFF
--- a/Sources/Accord.Imaging/IntegralImage2.cs
+++ b/Sources/Accord.Imaging/IntegralImage2.cs
@@ -158,6 +158,7 @@ namespace Accord.Imaging
             // check image format
             if (!(image.PixelFormat == PixelFormat.Format8bppIndexed ||
                 image.PixelFormat == PixelFormat.Format24bppRgb ||
+                image.PixelFormat == PixelFormat.Format32bppRgb ||
                 image.PixelFormat == PixelFormat.Format32bppArgb))
             {
                 throw new UnsupportedImageFormatException("Only grayscale and 24 bpp RGB images are supported.");
@@ -216,6 +217,7 @@ namespace Accord.Imaging
             // check image format
             if (!(image.PixelFormat == PixelFormat.Format8bppIndexed ||
                 image.PixelFormat == PixelFormat.Format24bppRgb ||
+                image.PixelFormat == PixelFormat.Format32bppRgb ||
                 image.PixelFormat == PixelFormat.Format32bppArgb))
             {
                 throw new UnsupportedImageFormatException("Only grayscale and 24 bpp RGB images are supported.");


### PR DESCRIPTION
There seems to be no reason for these not to be supported.
Testing HaarObjectDetector after this change seems to confirm that it works.
