### PR TITLE
test showing a bug in accord-net/framework/#13 along with the fix

### DIFF
--- a/Sources/Accord.MachineLearning/Bayes/NaiveBayes`1.cs
+++ b/Sources/Accord.MachineLearning/Bayes/NaiveBayes`1.cs
@@ -290,7 +290,7 @@ namespace Accord.MachineLearning.Bayes
         {
             if (classes <= 0) throw new ArgumentOutOfRangeException("classes");
             if (priors == null) throw new ArgumentNullException("priors");
-            if (priors.Length != classes) throw new DimensionMismatchException("priors");
+            if (priors.GetLength(0) != classes) throw new DimensionMismatchException("priors");
             if (classPriors.Length != classes) throw new DimensionMismatchException("classPriors");
 
             if (priors.GetLength(0) != classes)

--- a/Sources/Accord.Tests/Accord.Tests.MachineLearning/Bayes/NaiveBayes`1Test.cs
+++ b/Sources/Accord.Tests/Accord.Tests.MachineLearning/Bayes/NaiveBayes`1Test.cs
@@ -96,6 +96,29 @@ namespace Accord.Tests.MachineLearning
             }
         }
 
+        [TestMethod()]
+        public void NaiveBayesConstructorTest5()
+        {
+            const int classes = 2;
+            const int inputCount = 3;
+            double[] classPriors = {0.4, 0.6};
+            var inputPriors = new [,]
+            {
+                {new UniformDiscreteDistribution(0,10), new UniformDiscreteDistribution(0,10), new UniformDiscreteDistribution(0,10)},
+                {new UniformDiscreteDistribution(0,10), new UniformDiscreteDistribution(0,10), new UniformDiscreteDistribution(0,10)}
+            };
+
+            var target = new NaiveBayes<UniformDiscreteDistribution>(classes, inputCount, inputPriors, classPriors);
+
+            Assert.AreEqual(classes, target.ClassCount);
+            Assert.AreEqual(inputCount, target.InputCount);
+            Assert.AreEqual(classPriors.Length, target.Priors.Length);
+            Assert.AreEqual(0.4, target.Priors[0]);
+            Assert.AreEqual(0.6, target.Priors[1]);
+
+            Assert.AreEqual(2, target.Distributions.GetLength(0));
+            Assert.AreEqual(3, target.Distributions.GetLength(1));            
+        }
 
         [TestMethod()]
         public void ComputeTest()


### PR DESCRIPTION
in [NaiveBayes`1.cs:293](https://github.com/accord-net/framework/blob/ffe224211f01784b8a2354ac0b6aa19dbb0e98d3/Sources/Accord.MachineLearning/Bayes/NaiveBayes%601.cs#L293) we see the following

``` csharp
public NaiveBayes(int classes, int inputs, TDistribution[,] priors, double[] classPriors)
{
    if (classes <= 0) throw new ArgumentOutOfRangeException("classes");
    if (priors == null) throw new ArgumentNullException("priors");
    if (priors.Length != classes) throw new DimensionMismatchException("priors");
    if (classPriors.Length != classes) throw new DimensionMismatchException("classPriors");
```

The condition in the second line from bottom is incorrect for multidimensional arrays, whose `.Length` property returns the total number of elements in the array.  What we want here instead is `.GetLength(0)` to get the size of the first dimension.
