### PR TITLE
Updated tests to match correction in EmpiricalDistribution

### DIFF
--- a/Sources/Accord.Statistics/Distributions/Univariate/Continuous/EmpiricalDistribution.cs
+++ b/Sources/Accord.Statistics/Distributions/Univariate/Continuous/EmpiricalDistribution.cs
@@ -370,9 +370,6 @@ namespace Accord.Statistics.Distributions.Univariate
             if (weights != null)
                 throw new ArgumentException("This distribution does not support weighted samples.");
 
-            if (options != null)
-                throw new ArgumentException("This method does not accept fitting options.");
-
             double? smoothing = null;
 
             if (options != null)


### PR DESCRIPTION
For further information, see comments in associated [commit](https://github.com/accord-net/framework/commit/dbe8eeaddd1d3b720e4ba325e56c8cf85bffa339).

Hi Cesar,

I have now updated the unit tests along the lines that you drew up in the recent discussion. If there is something I have misinterpreted, just let me know and I can make the necessary corrections before you pull the request.

Regarding the additional `Fit` test that you proposed, `EmpiricalDistribution.Fit` previously threw when non-null `options` was passed. I simply removed this `if` statement, as you can see in the code changes below.

Best regards,
Anders
