### PR TITLE
implement a .Fit for Pareto.  Doesn't do anything with weights.

### DIFF
--- a/Sources/Accord.Statistics/Distributions/Univariate/Continuous/ParetoDistribution.cs
+++ b/Sources/Accord.Statistics/Distributions/Univariate/Continuous/ParetoDistribution.cs
@@ -20,6 +20,9 @@
 //    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+using System.Linq;
+using Accord.Math;
+
 namespace Accord.Statistics.Distributions.Univariate
 {
     using System;
@@ -263,6 +266,15 @@ namespace Accord.Statistics.Distributions.Univariate
             if (x >= xm)
                 return Math.Log(a) + a * Math.Log(xm) - (a + 1) * Math.Log(x);
             return 0;
+        }
+
+        /// <summary>
+        /// Approximates the Pareto parameters xm and alpha.
+        /// </summary>
+        public override void Fit(double[] observations, double[] weights, Fitting.IFittingOptions options)
+        {
+            xm = observations.Min();
+            a = observations.Length / (observations.Sum(o => Math.Log(o / xm)));
         }
 
         /// <summary>

--- a/Sources/Accord.Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/ParetoDistributionTest.cs
+++ b/Sources/Accord.Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/ParetoDistributionTest.cs
@@ -20,6 +20,8 @@
 //    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+using System.Linq;
+
 namespace Accord.Tests.Statistics
 {
     using Accord.Statistics.Distributions.Univariate;
@@ -131,6 +133,24 @@ namespace Accord.Tests.Statistics
             var target = new ParetoDistribution(scale: 7.12, shape: 2);
 
             Assert.AreEqual(target.Median, target.InverseDistributionFunction(0.5), 1e-6);
+        }
+
+        [TestMethod]
+        public void FitTest()
+        {
+            var source = new ParetoDistribution(scale: 7.12, shape: 2);
+            var sample = new double[10000];
+            var step = 1.0/sample.Length;
+            for (var i = 0; i < sample.Length; i++)
+            {
+                sample[i] = source.InverseDistributionFunction(i*step);
+            }
+
+            var target = new ParetoDistribution(0, 0);
+            target.Fit(sample);
+
+            Assert.AreEqual(7.12, target.Mode, 1e-6);
+            Assert.AreEqual(2.0, -target.Mean / (target.Mode - target.Mean), 1e-2);
         }
 
     }


### PR DESCRIPTION
A simple `ParetoDistribution.Fit`.  I don't know if this is complete enough to be included, really, but I needed something to keep it from blowing up with a `NotImplementedException`, which is what currently happens if you try to use Pareto and Bayes together.  

Unit test included.
