### PR TITLE
Accord.Math/Tools.cs: Handle temporary lack of support in Mono runtime

### DIFF
--- a/Sources/Accord.Math/Tools.cs
+++ b/Sources/Accord.Math/Tools.cs
@@ -36,11 +36,24 @@ namespace Accord.Math
     {
 
         #region Framework-wide random number generator
-        
+
 #if !NET35 && !NET40
-        private static ThreadLocal<Random> random = new ThreadLocal<Random>(create, true);
+        private static readonly ThreadLocal<Random> random;
+        
+        static Tools()
+        {
+            try
+            {
+                random = new ThreadLocal<Random>(create, true);
+            }
+            catch (NotImplementedException)
+            {
+                // Deal with a temporary shortcoming when targeting Mono runtime.
+                random = new ThreadLocal<Random>(create);
+            }
+        }
 #else
-        private static ThreadLocal<Random> random = new ThreadLocal<Random>(create);
+        private static readonly ThreadLocal<Random> random = new ThreadLocal<Random>(create);
 #endif
 
         private static int? seed;


### PR DESCRIPTION
When compiling for Mono, the `ThreadLocal<T>(Func<T> valueFactory, bool
trackAllValues)` constructor currently throws when `trackAllValues =
true`. To workaround this issue, the `random` variable is re-initialized
with a more fail-safe constructor if the first initalization throws.

[Reference](https://github.com/cureos/accord/issues/11)

Hi César,

this pull request is made from my "pull request" fork, which is identical to your main fork except for the pull request code. It should thus be straightforward to make the pull if you want to. Many thanks for your suggestion on how to solve this issue; way better than my own approach :-)

Best regards,
Anders