### PR TITLE
Removed unused Accord.Controls and System.Drawing usings

### DIFF
--- a/Unit Tests/Accord.Tests.Audio/ComplexSignalTest.cs
+++ b/Unit Tests/Accord.Tests.Audio/ComplexSignalTest.cs
@@ -29,7 +29,6 @@ namespace Accord.Tests.Audio
     using Accord.Math;
     using AForge.Math;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Accord.Controls;
     using System;
 
     [TestClass()]

--- a/Unit Tests/Accord.Tests.MachineLearning/RansacLineTest.cs
+++ b/Unit Tests/Accord.Tests.MachineLearning/RansacLineTest.cs
@@ -24,7 +24,6 @@ namespace Accord.Tests.MachineLearning
 {
     using System.Collections.Generic;
     using System.Drawing;
-    using Accord.Controls;
     using Accord.Imaging.Filters;
     using Accord.MachineLearning.Geometry;
     using AForge;
@@ -116,7 +115,7 @@ namespace Accord.Tests.MachineLearning
 
             Bitmap image = Properties.Resources.noise_line;
 
-            //ImageBox.Show(image); 
+            //Accord.Controls.ImageBox.Show(image); 
 
             var detector = new SusanCornersDetector();
 
@@ -124,7 +123,7 @@ namespace Accord.Tests.MachineLearning
             Assert.AreEqual(211, cloud.Count);
 
             Bitmap marks = new PointsMarker(cloud, Color.Pink).Apply(image);
-            //ImageBox.Show(marks);
+            //Accord.Controls.ImageBox.Show(marks);
 
             RansacLine ransac = new RansacLine(5, 1e-10);
             Line line = ransac.Estimate(cloud);
@@ -132,8 +131,8 @@ namespace Accord.Tests.MachineLearning
             Assert.AreEqual(0.501134932f, line.Intercept);
             Assert.AreEqual(-0.865369201f, line.Slope);
 
-            //Bitmap result = new LineMarker(line).Apply(image);
-            //ImageBox.Show(result);
+            //var result = new LineMarker(line).Apply(image);
+            //Accord.Controls.ImageBox.Show(result);
         }
 
     }

--- a/Unit Tests/Accord.Tests.Math/Geometry/ConvexHullDefectsTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Geometry/ConvexHullDefectsTest.cs
@@ -30,7 +30,6 @@ namespace Accord.Tests.Math
     using Accord.Math.Geometry;
     using AForge.Math.Geometry;
     using Accord.Imaging.Filters;
-    using Accord.Controls;
 
     [TestClass()]
     public class ConvexHullDefectsTest
@@ -79,7 +78,7 @@ namespace Accord.Tests.Math
             PointsMarker marker = new PointsMarker(contour);
             var bitmap = AForge.Imaging.Image.CreateGrayscaleImage(max + 1, max + 1);
             bitmap = marker.Apply(bitmap);
-            // ImageBox.Show(bitmap);
+            // Accord.Controls.ImageBox.Show(bitmap);
 
             GrahamConvexHull graham = new GrahamConvexHull();
             List<IntPoint> hull = graham.FindHull(contour);

--- a/Unit Tests/Accord.Tests.Math/Matrix/MatrixTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Matrix/MatrixTest.cs
@@ -30,7 +30,6 @@ namespace Accord.Tests.Math
     using Accord.Math.Decompositions;
     using AForge;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Accord.Controls;
 
     [TestClass()]
     public partial class MatrixTest
@@ -2809,7 +2808,7 @@ namespace Accord.Tests.Math
             );
 
             // Now we can plot the points on-screen
-            // ScatterplotBox.Show("Grid (step size)", grid).Hold();
+            // Accord.Controls.ScatterplotBox.Show("Grid (step size)", grid).Hold();
 
             Assert.AreEqual(55, grid.Length);
         }
@@ -2828,7 +2827,7 @@ namespace Accord.Tests.Math
             );
 
             // Now we can plot the points on-screen
-            // ScatterplotBox.Show("Grid (fixed steps)", grid).Hold();
+            // Accord.Controls.ScatterplotBox.Show("Grid (fixed steps)", grid).Hold();
 
             Assert.AreEqual(66, grid.Length);
         }

--- a/Unit Tests/Accord.Tests.Statistics/Analysis/CircularDescriptiveAnalysisTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Analysis/CircularDescriptiveAnalysisTest.cs
@@ -28,7 +28,6 @@ namespace Accord.Tests.Statistics
     using Accord.Statistics.Analysis;
     using AForge;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Accord.Controls;
 
     [TestClass()]
     public class CircularDescriptiveAnalysisTest
@@ -398,7 +397,7 @@ namespace Accord.Tests.Statistics
             Assert.AreEqual(m0, analysis.Measures["Column 0"]);
             Assert.AreEqual(m1, analysis.Measures["Column 1"]);
 
-            // var box = DataGridBox.Show(analysis.Measures);
+            // var box = Accord.Controls.DataGridBox.Show(analysis.Measures);
             // Assert.AreEqual(23, box.DataGridView.Columns.Count);
         }
     }

--- a/Unit Tests/Accord.Tests.Statistics/Analysis/DescriptiveAnalysisTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Analysis/DescriptiveAnalysisTest.cs
@@ -27,8 +27,6 @@ namespace Accord.Tests.Statistics
     using AForge;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
-    using System.Windows.Forms;
-    using Accord.Controls;
 
     [TestClass()]
     public class DescriptiveAnalysisTest
@@ -648,7 +646,7 @@ namespace Accord.Tests.Statistics
             Assert.AreEqual(m1, analysis.Measures["Column 1"]);
             Assert.AreEqual(m2, analysis.Measures["Column 2"]);
 
-            // var box = DataGridBox.Show(analysis.Measures);
+            // var box = Accord.Controls.DataGridBox.Show(analysis.Measures);
             // Assert.AreEqual(21, box.DataGridView.Columns.Count);
         }
     }

--- a/Unit Tests/Accord.Tests.Statistics/Analysis/LogisticRegressionAnalysisTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Analysis/LogisticRegressionAnalysisTest.cs
@@ -26,7 +26,6 @@ namespace Accord.Tests.Statistics
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using Accord.Math;
-    using Accord.Controls;
 
     [TestClass()]
     public class LogisticRegressionAnalysisTest
@@ -170,7 +169,7 @@ namespace Accord.Tests.Statistics
             regression.Compute(); // compute the analysis.
 
             // Now we can show a summary of the analysis
-            // DataGridBox.Show(regression.Coefficients);
+            // Accord.Controls.DataGridBox.Show(regression.Coefficients);
 
 
             // We can also investigate all parameters individually. For
@@ -236,7 +235,7 @@ namespace Accord.Tests.Statistics
             regression.Compute(); // compute the analysis.
 
             // Now we can show a summary of the analysis
-            // DataGridBox.Show(regression.Coefficients);
+            // Accord.Controls.DataGridBox.Show(regression.Coefficients);
 
 
             // We can also investigate all parameters individually. For

--- a/Unit Tests/Accord.Tests.Statistics/Analysis/MultinomialLogisticRegressionAnalysisTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Analysis/MultinomialLogisticRegressionAnalysisTest.cs
@@ -26,7 +26,6 @@ namespace Accord.Tests.Statistics
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using Accord.Math;
-    using Accord.Controls;
 
     [TestClass()]
     public class MultinomialLogisticRegressionAnalysisTest

--- a/Unit Tests/Accord.Tests.Statistics/Analysis/MultipleLinearRegressionAnalysisTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Analysis/MultipleLinearRegressionAnalysisTest.cs
@@ -29,7 +29,6 @@ namespace Accord.Tests.Statistics
     using AForge;
     using Accord.Statistics.Models.Regression.Linear;
     using Accord.Math;
-    using Accord.Controls;
     using Accord.Statistics.Testing;
 
     [TestClass()]
@@ -211,10 +210,10 @@ namespace Accord.Tests.Statistics
             regression.Compute(); // compute the analysis
 
             // Now we can show a summary of analysis
-            // DataGridBox.Show(regression.Coefficients);
+            // Accord.Controls.DataGridBox.Show(regression.Coefficients);
 
             // We can also show a summary ANOVA
-            // DataGridBox.Show(regression.Table);
+            // Accord.Controls.DataGridBox.Show(regression.Table);
 
 
             // And also extract other useful information, such

--- a/Unit Tests/Accord.Tests.Statistics/Analysis/ProportionalHazardsAnalysisTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Analysis/ProportionalHazardsAnalysisTest.cs
@@ -26,7 +26,6 @@ namespace Accord.Tests.Statistics
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using Accord.Math;
-    using Accord.Controls;
     using Accord.Statistics.Testing;
 
     [TestClass()]
@@ -89,7 +88,7 @@ namespace Accord.Tests.Statistics
             cox.Compute(); // compute the analysis
 
             // Now we can show an analysis summary
-            // DataGridBox.Show(cox.Coefficients);
+            // Accord.Controls.DataGridBox.Show(cox.Coefficients);
 
 
             // We can also investigate all parameters individually. For

--- a/Unit Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/CauchyDistributionTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/CauchyDistributionTest.cs
@@ -26,7 +26,6 @@ namespace Accord.Tests.Statistics
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using Accord.Statistics.Distributions.Fitting;
-    using Accord.Controls;
 
     [TestClass()]
     public class CauchyDistributionTest

--- a/Unit Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/ChiSquareDistributionTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/ChiSquareDistributionTest.cs
@@ -24,7 +24,6 @@ namespace Accord.Tests.Statistics
 {
     using Accord.Statistics.Distributions.Univariate;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Accord.Controls;
     using Accord.Math;
     using Accord.Statistics.Testing;
 

--- a/Unit Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/GompertzDistributionTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/GompertzDistributionTest.cs
@@ -24,7 +24,6 @@ namespace Accord.Tests.Statistics
 {
     using Accord.Statistics.Distributions.Univariate;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Accord.Controls;
     using Accord.Statistics.Testing;
 
     [TestClass()]

--- a/Unit Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/InverseChiSquareDistributionTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/InverseChiSquareDistributionTest.cs
@@ -24,7 +24,6 @@ namespace Accord.Tests.Statistics
 {
     using Accord.Statistics.Distributions.Univariate;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Accord.Controls;
     using Accord.Math;
     using Accord.Statistics.Testing;
 

--- a/Unit Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/InverseGaussianTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/InverseGaussianTest.cs
@@ -24,7 +24,6 @@ namespace Accord.Tests.Statistics
 {
     using Accord.Statistics.Distributions.Univariate;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Accord.Controls;
     using System.Globalization;
 
     [TestClass()]

--- a/Unit Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/LogNormalDistributionTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Distributions/Univariate/Continuous/LogNormalDistributionTest.cs
@@ -26,7 +26,6 @@ namespace Accord.Tests.Statistics
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using Accord.Statistics.Distributions.Fitting;
-    using Accord.Controls;
     using System.Globalization;
 
     [TestClass()]

--- a/Unit Tests/Accord.Tests.Statistics/Filters/CodificationFilterTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Filters/CodificationFilterTest.cs
@@ -29,7 +29,6 @@ namespace Accord.Tests.Statistics
     using Accord.Statistics.Filters;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Accord.IO;
-    using Accord.Controls;
     using System;
 
     [TestClass()]
@@ -57,7 +56,7 @@ namespace Accord.Tests.Statistics
             DataTable table = ProjectionFilterTest.CreateTable();
 
             // Show the start data
-            //DataGridBox.Show(table);
+            //Accord.Controls.DataGridBox.Show(table);
 
             // Create a new data projection (column) filter
             var filter = new Codification(table, "Category");
@@ -66,7 +65,7 @@ namespace Accord.Tests.Statistics
             DataTable result = filter.Apply(table);
 
             // Show it
-            //DataGridBox.Show(result);
+            //Accord.Controls.DataGridBox.Show(result);
 
             Assert.AreEqual(5, result.Columns.Count);
             Assert.AreEqual(5, result.Rows.Count);

--- a/Unit Tests/Accord.Tests.Statistics/Filters/NormalizationFilterTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Filters/NormalizationFilterTest.cs
@@ -22,7 +22,6 @@
 
 namespace Accord.Tests.Statistics
 {
-    using Accord.Controls;
     using Accord.Math;
     using Accord.Statistics.Filters;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -171,7 +170,7 @@ namespace Accord.Tests.Statistics
             // in which any column named "Age" will have been normalized
             // using the previously detected mean and standard deviation:
 
-            // DataGridBox.Show(result);
+            // Accord.Controls.DataGridBox.Show(result);
 
             Assert.AreEqual(25.555555555555557, mean);
             Assert.AreEqual(23.297591673342072, sdev);

--- a/Unit Tests/Accord.Tests.Statistics/Filters/ProjectionFilterTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Filters/ProjectionFilterTest.cs
@@ -27,7 +27,6 @@ namespace Accord.Tests.Statistics
     using System.Data;
     using Accord;
     using Accord.Math;
-    using Accord.Controls;
 
     [TestClass()]
     public class ProjectionFilterTest
@@ -69,7 +68,7 @@ namespace Accord.Tests.Statistics
             DataTable table = CreateTable();
 
             // Show the start data
-            // DataGridBox.Show(table);
+            // Accord.Controls.DataGridBox.Show(table);
 
             // Create a new data projection (column) filter
             var filter = new Projection("Floors", "Finished");
@@ -78,7 +77,7 @@ namespace Accord.Tests.Statistics
             DataTable result = filter.Apply(table);
 
             // Show it
-            // DataGridBox.Show(result);
+            // Accord.Controls.DataGridBox.Show(result);
 
             Assert.AreEqual(2, result.Columns.Count);
             Assert.AreEqual(5, result.Rows.Count);

--- a/Unit Tests/Accord.Tests.Statistics/Testing/OneWayAnovaTest.cs
+++ b/Unit Tests/Accord.Tests.Statistics/Testing/OneWayAnovaTest.cs
@@ -20,7 +20,6 @@
 //    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
-using Accord.Controls;
 using Accord.Statistics.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Accord.Math;
@@ -85,7 +84,7 @@ namespace Accord.Tests.Statistics
             // illustrate, we could use Accord.NET's DataGridBox to inspect the
             // table's contents.
 
-            // DataGridBox.Show(anova.Table);
+            // Accord.Controls.DataGridBox.Show(anova.Table);
 
             // The p-level for the analysis is about 0.002, meaning the test is
             // significant at the 5% significance level. The experimenter would


### PR DESCRIPTION
Hi César,

this is a little bit selfish of me :-), but it would make it easier for me to keep the unit tests in the portable Accord.NET repository in sync with your main repository if you would accept this pull request.

There are a number of otherwise non-UI unit tests where you have prepared for using some of the controls in the `Accord.Controls` namespace. The usage is however commented away, for example like this:

    //ImageBox.Show(image);

but the corresponding `using` cirective is still present in the file header:

    using Accord.Controls;

Since the controls in the `Accord.Controls` namespace are *Windows Forms*  controls, I have made no attempt of porting them to the portable repository.

Thus, when I try to build a unit test with the normally unused `using Accord.Controls` directive in the portable repository, I get a compilation error, since the `Accord.Controls` namespace is  missing.

Until now, I have manually removed these `usings`:s in the portable repository, but it can then sometimes be cumbersome to keep the files otherwise in sync with your main repository. Therefore I was wondering if you could instead drop the `using Accord.Controls` directives in the appropriate places in your code, and instead place the `Accord.Controls` namespace in the commented out usage of the controls, like this:

    //Accord.Controls.ImageBox.Show(image);

Then it would be very easy for you to remove the comment when you want to test in more detail, and the same code will be immediately "buildable" both in your main repository and in my portable fork.

What do you say, is this an acceptable solution to you?

Best regards,
Anders

PS1. I have not made any changes in the *Accord.Imaging* unit tests, since the impact of this proposed change is probably bigger there.
PS2. Along with the removal of `using Accord.Controls`, there is also a few removals of `using System.Drawing`. Please see the changes below.