### PR TITLE
Re-factor arguments into Stack<double>

### DIFF
--- a/Sources/Accord.Core/AForge/PolishExpression.cs
+++ b/Sources/Accord.Core/AForge/PolishExpression.cs
@@ -9,7 +9,7 @@
 namespace AForge
 {
     using System;
-    using System.Collections;
+    using System.Collections.Generic;
 
     // Quick and dirty implementation of polish expression evaluator
 
@@ -63,7 +63,7 @@ namespace AForge
             // split expression to separate tokens, which represent functions ans variables
             string[] tokens = expression.Trim( ).Split( ' ' );
             // arguments stack
-            Stack arguments = new Stack( );
+            Stack<double> arguments = new Stack<double>();
 
             // walk through all tokens
             foreach ( string token in tokens )

--- a/Unit Tests/Accord.Tests.Math/Accord.Tests.Math.csproj
+++ b/Unit Tests/Accord.Tests.Math/Accord.Tests.Math.csproj
@@ -179,6 +179,10 @@
       <Project>{F718E9A8-DB62-4785-8C49-4333A60D256A}</Project>
       <Name>Accord.Math</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Accord.Tests.Math.Cpp\Accord.Tests.Math.Cpp.vcxproj">
+      <Project>{161bd953-537d-4325-8a00-22475fc9088e}</Project>
+      <Name>Accord.Tests.Math.Cpp</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
Hi Cesar,

this may seem like a silly pull request, but here is a minor change of the recently added *AForge* code that improves type safety by using the generic `Stack<double>` instead of `Stack`.

The primary reason why I'd like to see this change is of course to facilitate porting *Accord.NET* to PCL :-) The non-generic `Stack` type is not available in PCL, whereas `Stack<T>` is.

Thanks in advance!
Anders