### PR TITLE
Use generic queue type to increase portability

### DIFF
--- a/Sources/Accord.Genetic/Chromosomes/GP/GEPChromosome.cs
+++ b/Sources/Accord.Genetic/Chromosomes/GP/GEPChromosome.cs
@@ -177,7 +177,7 @@ namespace AForge.Genetic
             // function node queue. the queue contains function node,
             // which requires children. when a function node receives
             // all children, it will be removed from the queue
-            Queue functionNodes = new Queue( );
+            Queue<GPTreeNode> functionNodes = new Queue<GPTreeNode>();
 
             // create root node
             GPTreeNode root = new GPTreeNode( genes[0] );


### PR DESCRIPTION
Hello again César!

Here is another minuscule pull request that will make the imported *AForge* code more portable and improve type safety. Once again, the request is primarily valuable to my PCL fork, but I hope should have at least some added value to your main fork as well.

Thanks in advance!
Anders