### PR TITLE
Remove unsafe from method API where sufficient. Issue #106

### DIFF
--- a/Sources/Accord.Audio/Generators/CosineGenerator.cs
+++ b/Sources/Accord.Audio/Generators/CosineGenerator.cs
@@ -95,27 +95,30 @@ namespace Accord.Audio.Generators
         ///   Generates a signal.
         /// </summary>
         /// 
-        public unsafe Signal Generate(int samples)
+        public Signal Generate(int samples)
         {
             Signal signal = new Signal(Channels, samples, SamplingRate, Format);
 
-            if (Format == SampleFormat.Format32BitIeeeFloat)
+            unsafe
             {
-                var dst = (float*)signal.Data.ToPointer();
-                for (int i = 0; i < signal.Samples; i++)
-                    for (int c = 0; c < signal.Channels; c++, dst++)
-                        *dst = (float)(Amplitude * Math.Cos(i * theta));
-            }
-            else if (Format == SampleFormat.Format64BitIeeeFloat)
-            {
-                var dst = (double*)signal.Data.ToPointer();
-                for (int i = 0; i < signal.Samples; i++)
-                    for (int c = 0; c < signal.Channels; c++, dst++)
-                        *dst = (Amplitude * Math.Cos(i * theta));
-            }
-            else
-            {
-                throw new UnsupportedSampleFormatException("Sample format is not supported by the filter.");
+                if (Format == SampleFormat.Format32BitIeeeFloat)
+                {
+                    var dst = (float*)signal.Data.ToPointer();
+                    for (int i = 0; i < signal.Samples; i++)
+                        for (int c = 0; c < signal.Channels; c++, dst++)
+                            *dst = (float)(Amplitude * Math.Cos(i * theta));
+                }
+                else if (Format == SampleFormat.Format64BitIeeeFloat)
+                {
+                    var dst = (double*)signal.Data.ToPointer();
+                    for (int i = 0; i < signal.Samples; i++)
+                        for (int c = 0; c < signal.Channels; c++, dst++)
+                            *dst = (Amplitude * Math.Cos(i * theta));
+                }
+                else
+                {
+                    throw new UnsupportedSampleFormatException("Sample format is not supported by the filter.");
+                }
             }
 
             return signal;

--- a/Sources/Accord.Audio/Generators/ImpulseGenerator.cs
+++ b/Sources/Accord.Audio/Generators/ImpulseGenerator.cs
@@ -98,47 +98,50 @@ namespace Accord.Audio.Generators
         ///   Generates the given number of samples.
         /// </summary>
         /// 
-        public unsafe Signal Generate(int samples)
+        public Signal Generate(int samples)
         {
             Signal signal = new Signal(Channels, samples, SamplingRate, Format);
 
             int ti = interval * Channels;
 
-            if (Format == SampleFormat.Format32BitIeeeFloat)
+            unsafe
             {
-                for (int c = 0; c < Channels; c++)
+                if (Format == SampleFormat.Format32BitIeeeFloat)
                 {
-                    float* dst = (float*)signal.Data.ToPointer() + c;
-
-                    for (int i = 0; i < samples; i += interval, dst += ti)
+                    for (int c = 0; c < Channels; c++)
                     {
-                        *dst = ampMax;
+                        float* dst = (float*)signal.Data.ToPointer() + c;
 
-                        if (Pulses > 0 && i / interval >= Pulses)
-                            break;
+                        for (int i = 0; i < samples; i += interval, dst += ti)
+                        {
+                            *dst = ampMax;
+
+                            if (Pulses > 0 && i / interval >= Pulses)
+                                break;
+                        }
                     }
                 }
-            }
-            else if (Format == SampleFormat.Format128BitComplex)
-            {
-                Complex campMax = new Complex(ampMax, 0);
-
-                for (int c = 0; c < Channels; c++)
+                else if (Format == SampleFormat.Format128BitComplex)
                 {
-                    Complex* dst = (Complex*)signal.Data.ToPointer() + c;
+                    Complex campMax = new Complex(ampMax, 0);
 
-                    for (int i = 0; i < samples; i += interval, dst += ti)
+                    for (int c = 0; c < Channels; c++)
                     {
-                        *dst = campMax;
+                        Complex* dst = (Complex*)signal.Data.ToPointer() + c;
 
-                        if (Pulses > 0 && i / interval >= Pulses)
-                            break;
+                        for (int i = 0; i < samples; i += interval, dst += ti)
+                        {
+                            *dst = campMax;
+
+                            if (Pulses > 0 && i / interval >= Pulses)
+                                break;
+                        }
                     }
                 }
-            }
-            else
-            {
-                throw new UnsupportedSampleFormatException("Sample format is not supported by the filter.");
+                else
+                {
+                    throw new UnsupportedSampleFormatException("Sample format is not supported by the filter.");
+                }
             }
 
             return signal;

--- a/Sources/Accord.Audio/Generators/SignalGenerator.cs
+++ b/Sources/Accord.Audio/Generators/SignalGenerator.cs
@@ -72,27 +72,30 @@ namespace Accord.Audio.Generators
         ///   Generates a signal.
         /// </summary>
         /// 
-        public unsafe Signal Generate(int samples)
+        public Signal Generate(int samples)
         {
             Signal signal = new Signal(Channels, samples, SamplingRate, Format);
 
-            if (Format == SampleFormat.Format32BitIeeeFloat)
+            unsafe
             {
-                var dst = (float*)signal.Data.ToPointer();
-                for (int i = 0; i < signal.Samples; i++)
-                    for (int c = 0; c < signal.Channels; c++, dst++)
-                        *dst = (float)(Function(i));
-            }
-            else if (Format == SampleFormat.Format64BitIeeeFloat)
-            {
-                var dst = (double*)signal.Data.ToPointer();
-                for (int i = 0; i < signal.Samples; i++)
-                    for (int c = 0; c < signal.Channels; c++, dst++)
-                        *dst = (double)(Function(i));
-            }
-            else
-            {
-                throw new UnsupportedSampleFormatException("Sample format is not supported by the filter.");
+                if (Format == SampleFormat.Format32BitIeeeFloat)
+                {
+                    var dst = (float*)signal.Data.ToPointer();
+                    for (int i = 0; i < signal.Samples; i++)
+                        for (int c = 0; c < signal.Channels; c++, dst++)
+                            *dst = (float)(Function(i));
+                }
+                else if (Format == SampleFormat.Format64BitIeeeFloat)
+                {
+                    var dst = (double*)signal.Data.ToPointer();
+                    for (int i = 0; i < signal.Samples; i++)
+                        for (int c = 0; c < signal.Channels; c++, dst++)
+                            *dst = (double)(Function(i));
+                }
+                else
+                {
+                    throw new UnsupportedSampleFormatException("Sample format is not supported by the filter.");
+                }
             }
 
             return signal;

--- a/Sources/Accord.Audio/Generators/SineGenerator.cs
+++ b/Sources/Accord.Audio/Generators/SineGenerator.cs
@@ -95,27 +95,30 @@ namespace Accord.Audio.Generators
         ///   Generates a signal.
         /// </summary>
         /// 
-        public unsafe Signal Generate(int samples)
+        public Signal Generate(int samples)
         {
             Signal signal = new Signal(Channels, samples, SamplingRate, Format);
 
-            if (Format == SampleFormat.Format32BitIeeeFloat)
+            unsafe
             {
-                var dst = (float*)signal.Data.ToPointer();
-                for (int i = 0; i < signal.Samples; i++)
-                    for (int c = 0; c < signal.Channels; c++, dst++)
-                        *dst = (float)(Amplitude * Math.Sin(i * theta));
-            }
-            else if (Format == SampleFormat.Format64BitIeeeFloat)
-            {
-                var dst = (double*)signal.Data.ToPointer();
-                for (int i = 0; i < signal.Samples; i++)
-                    for (int c = 0; c < signal.Channels; c++, dst++)
-                        *dst = (Amplitude * Math.Sin(i * theta));
-            }
-            else
-            {
-                throw new UnsupportedSampleFormatException("Sample format is not supported by the filter.");
+                if (Format == SampleFormat.Format32BitIeeeFloat)
+                {
+                    var dst = (float*)signal.Data.ToPointer();
+                    for (int i = 0; i < signal.Samples; i++)
+                        for (int c = 0; c < signal.Channels; c++, dst++)
+                            *dst = (float)(Amplitude * Math.Sin(i * theta));
+                }
+                else if (Format == SampleFormat.Format64BitIeeeFloat)
+                {
+                    var dst = (double*)signal.Data.ToPointer();
+                    for (int i = 0; i < signal.Samples; i++)
+                        for (int c = 0; c < signal.Channels; c++, dst++)
+                            *dst = (Amplitude * Math.Sin(i * theta));
+                }
+                else
+                {
+                    throw new UnsupportedSampleFormatException("Sample format is not supported by the filter.");
+                }
             }
 
             return signal;

--- a/Sources/Accord.Audio/Signals/Signal.cs
+++ b/Sources/Accord.Audio/Signals/Signal.cs
@@ -271,28 +271,31 @@ namespace Accord.Audio
         ///   Computes the signal energy.
         /// </summary>
         /// 
-        public unsafe double GetEnergy()
+        public double GetEnergy()
         {
             double e = 0, v;
 
-            if (format != SampleFormat.Format128BitComplex)
+            unsafe
             {
-                // Iterate over all samples and compute energy
-                float* src = (float*)this.ptrData.ToPointer();
-                for (int i = 0; i < this.Samples; i++, src++)
+                if (format != SampleFormat.Format128BitComplex)
                 {
-                    v = (*src);
-                    e += v * v;
+                    // Iterate over all samples and compute energy
+                    float* src = (float*)this.ptrData.ToPointer();
+                    for (int i = 0; i < this.Samples; i++, src++)
+                    {
+                        v = (*src);
+                        e += v * v;
+                    }
                 }
-            }
-            else
-            {
-                // Iterate over all samples and compute energy
-                Complex* src = (Complex*)this.Data.ToPointer();
-                for (int i = 0; i < this.Samples; i++, src++)
+                else
                 {
-                    double m = (*src).Magnitude;
-                    e += m * m;
+                    // Iterate over all samples and compute energy
+                    Complex* src = (Complex*)this.Data.ToPointer();
+                    for (int i = 0; i < this.Samples; i++, src++)
+                    {
+                        double m = (*src).Magnitude;
+                        e += m * m;
+                    }
                 }
             }
 
@@ -309,19 +312,26 @@ namespace Accord.Audio
         ///   the retrieved value. Conversion is performed automatically from
         ///   the underlying signal sample format if supported.</returns>
         ///   
-        public unsafe float GetSample(int channel, int position)
+        public float GetSample(int channel, int position)
         {
-            void* ptr = ptrData.ToPointer();
-            int pos = position * Channels + channel;
+            float sample;
 
-            switch (format)
+            unsafe
             {
-                case SampleFormat.Format32BitIeeeFloat:
-                    return ((float*)ptr)[pos];
+                void* ptr = ptrData.ToPointer();
+                int pos = position * Channels + channel;
 
-                default:
-                    throw new NotSupportedException();
+                switch (format)
+                {
+                    case SampleFormat.Format32BitIeeeFloat:
+                        sample = ((float*)ptr)[pos];
+                        break;
+                    default:
+                        throw new NotSupportedException();
+                }
             }
+
+            return sample;
         }
 
         /// <summary>
@@ -334,19 +344,22 @@ namespace Accord.Audio
         ///   specifying the value to set. Conversion will be done automatically
         ///   to the underlying signal sample format if supported.</param>
         ///   
-        public unsafe void SetSample(int channel, int position, float value)
+        public void SetSample(int channel, int position, float value)
         {
-            void* ptr = ptrData.ToPointer();
-            int pos = position * Channels + channel;
-
-            switch (format)
+            unsafe
             {
-                case SampleFormat.Format32BitIeeeFloat:
-                    ((float*)ptr)[pos] = value;
-                    break;
+                void* ptr = ptrData.ToPointer();
+                int pos = position * Channels + channel;
 
-                default:
-                    throw new NotSupportedException();
+                switch (format)
+                {
+                    case SampleFormat.Format32BitIeeeFloat:
+                        ((float*)ptr)[pos] = value;
+                        break;
+
+                    default:
+                        throw new NotSupportedException();
+                }
             }
         }
 

--- a/Sources/Accord.Audio/Windows/RectangularWindow.cs
+++ b/Sources/Accord.Audio/Windows/RectangularWindow.cs
@@ -92,7 +92,7 @@ namespace Accord.Audio.Windows
         ///   Splits a signal using the current window.
         /// </summary>
         /// 
-        public unsafe Signal Apply(Signal signal, int sampleIndex)
+        public Signal Apply(Signal signal, int sampleIndex)
         {
             int channels = signal.Channels;
             int samples = signal.Length;
@@ -105,12 +105,15 @@ namespace Accord.Audio.Windows
             {
                 for (int c = 0; c < channels; c++)
                 {
-                    float* dst = (float*)result.Data.ToPointer() + c;
-                    float* src = (float*)signal.Data.ToPointer() + c + channels * sampleIndex;
-
-                    for (int i = 0; i < minLength; i++, dst += channels, src += channels)
+                    unsafe
                     {
-                        *dst = *src;
+                        float* dst = (float*)result.Data.ToPointer() + c;
+                        float* src = (float*)signal.Data.ToPointer() + c + channels * sampleIndex;
+
+                        for (int i = 0; i < minLength; i++, dst += channels, src += channels)
+                        {
+                            *dst = *src;
+                        }
                     }
                 }
             }
@@ -155,20 +158,23 @@ namespace Accord.Audio.Windows
         ///   Splits a signal using the window.
         /// </summary>
         /// 
-        public unsafe virtual double[] Apply(double[] signal, int sampleIndex)
+        public virtual double[] Apply(double[] signal, int sampleIndex)
         {
             int minLength = System.Math.Min(signal.Length - sampleIndex, Length);
 
             double[] result = new double[Length];
 
-            fixed (double* R = result)
-            fixed (double* S = signal)
+            unsafe
             {
-                double* dst = R;
-                double* src = S + sampleIndex;
+                fixed (double* R = result)
+                fixed (double* S = signal)
+                {
+                    double* dst = R;
+                    double* src = S + sampleIndex;
 
-                for (int i = 0; i < minLength; i++, dst++, src++)
-                    *dst = *src;
+                    for (int i = 0; i < minLength; i++, dst++, src++)
+                        *dst = *src;
+                }
             }
 
             return result;
@@ -178,7 +184,7 @@ namespace Accord.Audio.Windows
         ///   Splits a signal using the window.
         /// </summary>
         /// 
-        public unsafe virtual double[][] Apply(double[][] signal, int sampleIndex)
+        public virtual double[][] Apply(double[][] signal, int sampleIndex)
         {
             int channels = signal[0].Length;
 

--- a/Sources/Accord.Audio/Windows/WindowBase.cs
+++ b/Sources/Accord.Audio/Windows/WindowBase.cs
@@ -95,7 +95,7 @@ namespace Accord.Audio.Windows
         ///   Splits a signal using the window.
         /// </summary>
         /// 
-        public unsafe virtual Signal Apply(Signal signal, int sampleIndex)
+        public virtual Signal Apply(Signal signal, int sampleIndex)
         {
             int channels = signal.Channels;
 
@@ -107,12 +107,15 @@ namespace Accord.Audio.Windows
             {
                 for (int c = 0; c < channels; c++)
                 {
-                    float* dst = (float*)result.Data.ToPointer() + c;
-                    float* src = (float*)signal.Data.ToPointer() + c + channels * sampleIndex;
-
-                    for (int i = 0; i < minLength; i++, dst += channels, src += channels)
+                    unsafe
                     {
-                        *dst = window[i] * (*src);
+                        float* dst = (float*)result.Data.ToPointer() + c;
+                        float* src = (float*)signal.Data.ToPointer() + c + channels * sampleIndex;
+
+                        for (int i = 0; i < minLength; i++, dst += channels, src += channels)
+                        {
+                            *dst = window[i] * (*src);
+                        }
                     }
                 }
             }
@@ -154,21 +157,24 @@ namespace Accord.Audio.Windows
         ///   Splits a signal using the window.
         /// </summary>
         /// 
-        public unsafe virtual double[] Apply(double[] signal, int sampleIndex)
+        public virtual double[] Apply(double[] signal, int sampleIndex)
         {
             int minLength = System.Math.Min(signal.Length - sampleIndex, Length);
 
             double[] result = new double[Length];
 
-            fixed (double* R = result)
-            fixed (double* S = signal)
+            unsafe
             {
-                double* dst = R;
-                double* src = S + sampleIndex;
-
-                for (int i = 0; i < minLength; i++, dst++, src++)
+                fixed (double* R = result)
+                fixed (double* S = signal)
                 {
-                    *dst = window[i] * (*src);
+                    double* dst = R;
+                    double* src = S + sampleIndex;
+
+                    for (int i = 0; i < minLength; i++, dst++, src++)
+                    {
+                        *dst = window[i] * (*src);
+                    }
                 }
             }
 
@@ -179,7 +185,7 @@ namespace Accord.Audio.Windows
         ///   Splits a signal using the window.
         /// </summary>
         /// 
-        public unsafe virtual double[][] Apply(double[][] signal, int sampleIndex)
+        public virtual double[][] Apply(double[][] signal, int sampleIndex)
         {
             int channels = signal[0].Length;
 

--- a/Sources/Accord.Core/AForge/SystemTools.cs
+++ b/Sources/Accord.Core/AForge/SystemTools.cs
@@ -36,9 +36,12 @@ namespace AForge
         /// not provide any way to copy unmanaged blocks, but provides only methods to
         /// copy from unmanaged memory to managed memory and vise versa.</para></remarks>
         ///
-        public unsafe static IntPtr CopyUnmanagedMemory(IntPtr dst, IntPtr src, int count)
+        public static IntPtr CopyUnmanagedMemory(IntPtr dst, IntPtr src, int count)
         {
-            CopyUnmanagedMemory((byte*)dst.ToPointer(), (byte*)src.ToPointer(), count);
+            unsafe
+            {
+                CopyUnmanagedMemory((byte*)dst.ToPointer(), (byte*)src.ToPointer(), count);
+            }
             return dst;
         }
 
@@ -71,9 +74,12 @@ namespace AForge
         /// 
         /// <returns>Return's value of <paramref name="dst"/> - pointer to destination.</returns>
         /// 
-        public unsafe static IntPtr SetUnmanagedMemory(IntPtr dst, int filler, int count)
+        public static IntPtr SetUnmanagedMemory(IntPtr dst, int filler, int count)
         {
-            SetUnmanagedMemory((byte*)dst.ToPointer(), filler, count);
+            unsafe
+            {
+                SetUnmanagedMemory((byte*)dst.ToPointer(), filler, count);
+            }
             return dst;
         }
 

--- a/Sources/Accord.Imaging/Converters/ImageToArray.cs
+++ b/Sources/Accord.Imaging/Converters/ImageToArray.cs
@@ -305,7 +305,7 @@ namespace Accord.Imaging.Converters
         /// <param name="input">The input image to be converted.</param>
         /// <param name="output">The converted image.</param>
         /// 
-        public unsafe void Convert(UnmanagedImage input, out double[] output)
+        public void Convert(UnmanagedImage input, out double[] output)
         {
             int width = input.Width;
             int height = input.Height;
@@ -314,30 +314,33 @@ namespace Accord.Imaging.Converters
 
             output = new double[width * height];
 
-            if (input.PixelFormat == PixelFormat.Format16bppGrayScale)
+            unsafe
             {
-                short* src = (short*)input.ImageData.ToPointer();
-                int dst = 0;
-
-                for (int y = 0; y < height; y++)
+                if (input.PixelFormat == PixelFormat.Format16bppGrayScale)
                 {
-                    for (int x = 0; x < width; x++, dst++, src++)
-                        output[dst] = Accord.Math.Tools.Scale(0, 65535, Min, Max, *src);
+                    short* src = (short*)input.ImageData.ToPointer();
+                    int dst = 0;
 
-                    src += offset;
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, dst++, src++)
+                            output[dst] = Accord.Math.Tools.Scale(0, 65535, Min, Max, *src);
+
+                        src += offset;
+                    }
                 }
-            }
-            else
-            {
-                byte* src = (byte*)input.ImageData.ToPointer() + Channel;
-                int dst = 0;
-
-                for (int y = 0; y < height; y++)
+                else
                 {
-                    for (int x = 0; x < width; x++, dst++, src += pixelSize)
-                        output[dst] = Accord.Math.Tools.Scale(0, 255, Min, Max, *src);
+                    byte* src = (byte*)input.ImageData.ToPointer() + Channel;
+                    int dst = 0;
 
-                    src += offset;
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, dst++, src += pixelSize)
+                            output[dst] = Accord.Math.Tools.Scale(0, 255, Min, Max, *src);
+
+                        src += offset;
+                    }
                 }
             }
         }
@@ -349,7 +352,7 @@ namespace Accord.Imaging.Converters
         /// <param name="input">The input image to be converted.</param>
         /// <param name="output">The converted image.</param>
         /// 
-        public unsafe void Convert(UnmanagedImage input, out float[] output)
+        public void Convert(UnmanagedImage input, out float[] output)
         {
             int width = input.Width;
             int height = input.Height;
@@ -361,30 +364,33 @@ namespace Accord.Imaging.Converters
             float min = (float)Min;
             float max = (float)Max;
 
-            if (input.PixelFormat == PixelFormat.Format16bppGrayScale)
+            unsafe
             {
-                short* src = (short*)input.ImageData.ToPointer();
-                int dst = 0;
-
-                for (int y = 0; y < height; y++)
+                if (input.PixelFormat == PixelFormat.Format16bppGrayScale)
                 {
-                    for (int x = 0; x < width; x++, dst++, src++)
-                        output[dst] = Accord.Math.Tools.Scale(0, 65535, min, max, *src);
+                    short* src = (short*)input.ImageData.ToPointer();
+                    int dst = 0;
 
-                    src += offset;
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, dst++, src++)
+                            output[dst] = Accord.Math.Tools.Scale(0, 65535, min, max, *src);
+
+                        src += offset;
+                    }
                 }
-            }
-            else
-            {
-                byte* src = (byte*)input.ImageData.ToPointer() + Channel;
-                int dst = 0;
-
-                for (int y = 0; y < height; y++)
+                else
                 {
-                    for (int x = 0; x < width; x++, dst++, src += pixelSize)
-                        output[dst] = Accord.Math.Tools.Scale(0, 255, min, max, *src);
+                    byte* src = (byte*)input.ImageData.ToPointer() + Channel;
+                    int dst = 0;
 
-                    src += offset;
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, dst++, src += pixelSize)
+                            output[dst] = Accord.Math.Tools.Scale(0, 255, min, max, *src);
+
+                        src += offset;
+                    }
                 }
             }
         }
@@ -396,7 +402,7 @@ namespace Accord.Imaging.Converters
         /// <param name="input">The input image to be converted.</param>
         /// <param name="output">The converted image.</param>
         /// 
-        public unsafe void Convert(UnmanagedImage input, out Color[] output)
+        public void Convert(UnmanagedImage input, out Color[] output)
         {
             int width = input.Width;
             int height = input.Height;
@@ -407,43 +413,46 @@ namespace Accord.Imaging.Converters
             output = new Color[input.Width * input.Height];
             int dst = 0;
 
-            if (input.PixelFormat == PixelFormat.Format8bppIndexed)
+            unsafe
             {
-                byte* src = (byte*)input.ImageData.ToPointer();
-
-                for (int y = 0; y < height; y++)
+                if (input.PixelFormat == PixelFormat.Format8bppIndexed)
                 {
-                    for (int x = 0; x < width; x++, src += pixelSize, dst++)
-                        output[dst] = Color.FromArgb(*src, *src, *src);
-                    src += offset;
-                }
-            }
-            else if (input.PixelFormat == PixelFormat.Format24bppRgb
-                  || input.PixelFormat == PixelFormat.Format32bppRgb)
-            {
-                byte* src = (byte*)input.ImageData.ToPointer();
+                    byte* src = (byte*)input.ImageData.ToPointer();
 
-                for (int y = 0; y < height; y++)
-                {
-                    for (int x = 0; x < width; x++, src += pixelSize, dst++)
-                        output[dst] = Color.FromArgb(src[RGB.R], src[RGB.G], src[RGB.B]);
-                    src += offset;
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, src += pixelSize, dst++)
+                            output[dst] = Color.FromArgb(*src, *src, *src);
+                        src += offset;
+                    }
                 }
-            }
-            else if (input.PixelFormat == PixelFormat.Format32bppArgb)
-            {
-                byte* src = (byte*)input.ImageData.ToPointer();
+                else if (input.PixelFormat == PixelFormat.Format24bppRgb
+                      || input.PixelFormat == PixelFormat.Format32bppRgb)
+                {
+                    byte* src = (byte*)input.ImageData.ToPointer();
 
-                for (int y = 0; y < height; y++)
-                {
-                    for (int x = 0; x < width; x++, src += pixelSize, dst++)
-                        output[dst] = Color.FromArgb(src[RGB.A], src[RGB.R], src[RGB.G], src[RGB.B]);
-                    src += offset;
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, src += pixelSize, dst++)
+                            output[dst] = Color.FromArgb(src[RGB.R], src[RGB.G], src[RGB.B]);
+                        src += offset;
+                    }
                 }
-            }
-            else
-            {
-                throw new UnsupportedImageFormatException("Pixel format is not supported.");
+                else if (input.PixelFormat == PixelFormat.Format32bppArgb)
+                {
+                    byte* src = (byte*)input.ImageData.ToPointer();
+
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, src += pixelSize, dst++)
+                            output[dst] = Color.FromArgb(src[RGB.A], src[RGB.R], src[RGB.G], src[RGB.B]);
+                        src += offset;
+                    }
+                }
+                else
+                {
+                    throw new UnsupportedImageFormatException("Pixel format is not supported.");
+                }
             }
         }
 

--- a/Sources/Accord.Imaging/Converters/ImageToMatrix.cs
+++ b/Sources/Accord.Imaging/Converters/ImageToMatrix.cs
@@ -239,7 +239,7 @@ namespace Accord.Imaging.Converters
         /// <param name="input">The input image to be converted.</param>
         /// <param name="output">The converted image.</param>
         /// 
-        public unsafe void Convert(UnmanagedImage input, out double[,] output)
+        public void Convert(UnmanagedImage input, out double[,] output)
         {
             int width = input.Width;
             int height = input.Height;
@@ -248,16 +248,19 @@ namespace Accord.Imaging.Converters
 
             output = new double[height, width];
 
-            fixed (double* ptrData = output)
+            unsafe
             {
-                double* dst = ptrData;
-                byte* src = (byte*)input.ImageData.ToPointer() + Channel;
-
-                for (int y = 0; y < height; y++)
+                fixed (double* ptrData = output)
                 {
-                    for (int x = 0; x < width; x++, src += pixelSize, dst++)
-                        *dst = Accord.Math.Tools.Scale(0, 255, Min, Max, *src);
-                    src += offset;
+                    double* dst = ptrData;
+                    byte* src = (byte*)input.ImageData.ToPointer() + Channel;
+
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, src += pixelSize, dst++)
+                            *dst = Accord.Math.Tools.Scale(0, 255, Min, Max, *src);
+                        src += offset;
+                    }
                 }
             }
         }
@@ -307,7 +310,7 @@ namespace Accord.Imaging.Converters
         /// <param name="input">The input image to be converted.</param>
         /// <param name="output">The converted image.</param>
         /// 
-        public unsafe void Convert(UnmanagedImage input, out byte[,] output)
+        public void Convert(UnmanagedImage input, out byte[,] output)
         {
             int width = input.Width;
             int height = input.Height;
@@ -316,16 +319,19 @@ namespace Accord.Imaging.Converters
 
             output = new byte[height, width];
 
-            fixed (byte* ptrData = output)
+            unsafe
             {
-                byte* dst = ptrData;
-                byte* src = (byte*)input.ImageData.ToPointer() + Channel;
-
-                for (int y = 0; y < height; y++)
+                fixed (byte* ptrData = output)
                 {
-                    for (int x = 0; x < width; x++, src += pixelSize, dst++)
-                        *dst = *src;
-                    src += offset;
+                    byte* dst = ptrData;
+                    byte* src = (byte*)input.ImageData.ToPointer() + Channel;
+
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, src += pixelSize, dst++)
+                            *dst = *src;
+                        src += offset;
+                    }
                 }
             }
         }
@@ -339,7 +345,7 @@ namespace Accord.Imaging.Converters
         /// <param name="input">The input image to be converted.</param>
         /// <param name="output">The converted image.</param>
         /// 
-        public unsafe void Convert(UnmanagedImage input, out Color[,] output)
+        public void Convert(UnmanagedImage input, out Color[,] output)
         {
             int width = input.Width;
             int height = input.Height;
@@ -349,43 +355,46 @@ namespace Accord.Imaging.Converters
 
             output = new Color[input.Height, input.Width];
 
-            if (input.PixelFormat == PixelFormat.Format8bppIndexed)
+            unsafe
             {
-                byte* src = (byte*)input.ImageData.ToPointer();
-
-                for (int y = 0; y < height; y++)
+                if (input.PixelFormat == PixelFormat.Format8bppIndexed)
                 {
-                    for (int x = 0; x < width; x++, src += pixelSize)
-                        output[y, x] = Color.FromArgb(*src, *src, *src);
-                    src += offset;
-                }
-            }
-            else if (input.PixelFormat == PixelFormat.Format24bppRgb
-                  || input.PixelFormat == PixelFormat.Format32bppRgb)
-            {
-                byte* src = (byte*)input.ImageData.ToPointer();
+                    byte* src = (byte*)input.ImageData.ToPointer();
 
-                for (int y = 0; y < height; y++)
-                {
-                    for (int x = 0; x < width; x++, src += pixelSize)
-                        output[y, x] = Color.FromArgb(src[RGB.R], src[RGB.G], src[RGB.B]);
-                    src += offset;
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, src += pixelSize)
+                            output[y, x] = Color.FromArgb(*src, *src, *src);
+                        src += offset;
+                    }
                 }
-            }
-            else if (input.PixelFormat == PixelFormat.Format32bppArgb)
-            {
-                byte* src = (byte*)input.ImageData.ToPointer();
+                else if (input.PixelFormat == PixelFormat.Format24bppRgb
+                      || input.PixelFormat == PixelFormat.Format32bppRgb)
+                {
+                    byte* src = (byte*)input.ImageData.ToPointer();
 
-                for (int y = 0; y < height; y++)
-                {
-                    for (int x = 0; x < width; x++, src += pixelSize)
-                        output[y, x] = Color.FromArgb(src[RGB.A], src[RGB.R], src[RGB.G], src[RGB.B]);
-                    src += offset;
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, src += pixelSize)
+                            output[y, x] = Color.FromArgb(src[RGB.R], src[RGB.G], src[RGB.B]);
+                        src += offset;
+                    }
                 }
-            }
-            else
-            {
-                throw new UnsupportedImageFormatException("Pixel format is not supported.");
+                else if (input.PixelFormat == PixelFormat.Format32bppArgb)
+                {
+                    byte* src = (byte*)input.ImageData.ToPointer();
+
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, src += pixelSize)
+                            output[y, x] = Color.FromArgb(src[RGB.A], src[RGB.R], src[RGB.G], src[RGB.B]);
+                        src += offset;
+                    }
+                }
+                else
+                {
+                    throw new UnsupportedImageFormatException("Pixel format is not supported.");
+                }
             }
         }
 

--- a/Sources/Accord.Imaging/GrayLevelDifferenceMethod.cs
+++ b/Sources/Accord.Imaging/GrayLevelDifferenceMethod.cs
@@ -102,7 +102,7 @@ namespace Accord.Imaging
         /// <returns>An histogram containing co-occurrences 
         /// for every gray level in <paramref name="source"/>.</returns>
         /// 
-        public unsafe int[] Compute(UnmanagedImage source)
+        public int[] Compute(UnmanagedImage source)
         {
             int width = source.Width;
             int height = source.Height;
@@ -110,68 +110,73 @@ namespace Accord.Imaging
             int offset = stride - width;
             int maxGray = 255;
 
-            byte* src = (byte*)source.ImageData.ToPointer();
+            int[] hist;
 
-            if (autoGray)
-                maxGray = max(width, height, offset, src);
-
-
-            int[] hist = new int[maxGray + 1];
-
-            switch (degree)
+            unsafe
             {
-                case CooccurrenceDegree.Degree0:
-                    for (int y = 0; y < height; y++)
-                    {
-                        for (int x = 1; x < width; x++)
-                        {
-                            byte a = src[stride * y + (x - 1)];
-                            byte b = src[stride * y + x];
-                            int bin = Math.Abs(a - b);
-                            hist[bin]++;
-                        }
-                    }
-                    break;
+                byte* src = (byte*)source.ImageData.ToPointer();
 
-                case CooccurrenceDegree.Degree45:
-                    for (int y = 1; y < height; y++)
-                    {
-                        for (int x = 0; x < width - 1; x++)
-                        {
-                            byte a = src[stride * y + x];
-                            byte b = src[stride * (y - 1) + (x + 1)];
-                            int bin = Math.Abs(a - b);
-                            hist[bin]++;
-                        }
-                    }
-                    break;
+                if (autoGray)
+                    maxGray = max(width, height, offset, src);
 
-                case CooccurrenceDegree.Degree90:
-                    for (int y = 1; y < height; y++)
-                    {
-                        for (int x = 0; x < width; x++)
-                        {
-                            byte a = src[stride * (y - 1) + x];
-                            byte b = src[stride * y + x];
-                            int bin = Math.Abs(a - b);
-                            hist[bin]++;
-                        }
-                    }
-                    break;
 
-                case CooccurrenceDegree.Degree135:
-                    for (int y = 1; y < height; y++)
-                    {
-                        int steps = width - 1;
-                        for (int x = 0; x < width - 1; x++)
+                hist = new int[maxGray + 1];
+
+                switch (degree)
+                {
+                    case CooccurrenceDegree.Degree0:
+                        for (int y = 0; y < height; y++)
                         {
-                            byte a = src[stride * y + (steps - x)];
-                            byte b = src[stride * (y - 1) + (steps - 1 - x)];
-                            int bin = Math.Abs(a - b);
-                            hist[bin]++;
+                            for (int x = 1; x < width; x++)
+                            {
+                                byte a = src[stride * y + (x - 1)];
+                                byte b = src[stride * y + x];
+                                int bin = Math.Abs(a - b);
+                                hist[bin]++;
+                            }
                         }
-                    }
-                    break;
+                        break;
+
+                    case CooccurrenceDegree.Degree45:
+                        for (int y = 1; y < height; y++)
+                        {
+                            for (int x = 0; x < width - 1; x++)
+                            {
+                                byte a = src[stride * y + x];
+                                byte b = src[stride * (y - 1) + (x + 1)];
+                                int bin = Math.Abs(a - b);
+                                hist[bin]++;
+                            }
+                        }
+                        break;
+
+                    case CooccurrenceDegree.Degree90:
+                        for (int y = 1; y < height; y++)
+                        {
+                            for (int x = 0; x < width; x++)
+                            {
+                                byte a = src[stride * (y - 1) + x];
+                                byte b = src[stride * y + x];
+                                int bin = Math.Abs(a - b);
+                                hist[bin]++;
+                            }
+                        }
+                        break;
+
+                    case CooccurrenceDegree.Degree135:
+                        for (int y = 1; y < height; y++)
+                        {
+                            int steps = width - 1;
+                            for (int x = 0; x < width - 1; x++)
+                            {
+                                byte a = src[stride * y + (steps - x)];
+                                byte b = src[stride * (y - 1) + (steps - 1 - x)];
+                                int bin = Math.Abs(a - b);
+                                hist[bin]++;
+                            }
+                        }
+                        break;
+                }
             }
 
             return hist;

--- a/Sources/Accord.Imaging/Interest Points/Haralick/Haralick.cs
+++ b/Sources/Accord.Imaging/Interest Points/Haralick/Haralick.cs
@@ -241,7 +241,7 @@ namespace Accord.Imaging
         ///   The source image has incorrect pixel format.
         /// </exception>
         /// 
-        public unsafe List<double[]> ProcessImage(UnmanagedImage image)
+        public List<double[]> ProcessImage(UnmanagedImage image)
         {
 
             // check image format

--- a/Sources/Accord.Imaging/Interest Points/LocalBinaryPattern.cs
+++ b/Sources/Accord.Imaging/Interest Points/LocalBinaryPattern.cs
@@ -138,7 +138,7 @@ namespace Accord.Imaging
         ///   The source image has incorrect pixel format.
         /// </exception>
         /// 
-        public unsafe List<double[]> ProcessImage(UnmanagedImage image)
+        public List<double[]> ProcessImage(UnmanagedImage image)
         {
 
             // check image format
@@ -175,41 +175,44 @@ namespace Accord.Imaging
             // 1. Calculate 8-pixel neighborhood binary patterns 
             patterns = new int[height, width];
 
-            fixed (int* ptrPatterns = patterns)
+            unsafe
             {
-                // Begin skipping first line
-                byte* src = (byte*)grayImage.ImageData.ToPointer() + stride;
-                int* neighbors = ptrPatterns + width;
-
-                // for each line
-                for (int y = 1; y < height - 1; y++)
+                fixed (int* ptrPatterns = patterns)
                 {
-                    // skip first column
-                    neighbors++; src++;
+                    // Begin skipping first line
+                    byte* src = (byte*)grayImage.ImageData.ToPointer() + stride;
+                    int* neighbors = ptrPatterns + width;
 
-                    // for each inner pixel in line (skipping first and last)
-                    for (int x = 1; x < width - 1; x++, src++, neighbors++)
+                    // for each line
+                    for (int y = 1; y < height - 1; y++)
                     {
-                        // Retrieve the pixel neighborhood
-                        byte a11 = src[+stride + 1], a12 = src[+1], a13 = src[-stride + 1];
-                        byte a21 = src[+stride + 0], a22 = src[0], a23 = src[-stride + 0];
-                        byte a31 = src[+stride - 1], a32 = src[-1], a33 = src[-stride - 1];
+                        // skip first column
+                        neighbors++; src++;
 
-                        int sum = 0;
-                        if (a22 < a11) sum += 1 << 0;
-                        if (a22 < a12) sum += 1 << 1;
-                        if (a22 < a13) sum += 1 << 2;
-                        if (a22 < a21) sum += 1 << 3;
-                        if (a22 < a23) sum += 1 << 4;
-                        if (a22 < a31) sum += 1 << 5;
-                        if (a22 < a32) sum += 1 << 6;
-                        if (a22 < a33) sum += 1 << 7;
+                        // for each inner pixel in line (skipping first and last)
+                        for (int x = 1; x < width - 1; x++, src++, neighbors++)
+                        {
+                            // Retrieve the pixel neighborhood
+                            byte a11 = src[+stride + 1], a12 = src[+1], a13 = src[-stride + 1];
+                            byte a21 = src[+stride + 0], a22 = src[0], a23 = src[-stride + 0];
+                            byte a31 = src[+stride - 1], a32 = src[-1], a33 = src[-stride - 1];
 
-                        *neighbors = sum;
+                            int sum = 0;
+                            if (a22 < a11) sum += 1 << 0;
+                            if (a22 < a12) sum += 1 << 1;
+                            if (a22 < a13) sum += 1 << 2;
+                            if (a22 < a21) sum += 1 << 3;
+                            if (a22 < a23) sum += 1 << 4;
+                            if (a22 < a31) sum += 1 << 5;
+                            if (a22 < a32) sum += 1 << 6;
+                            if (a22 < a33) sum += 1 << 7;
+
+                            *neighbors = sum;
+                        }
+
+                        // Skip last column
+                        neighbors++; src += offset + 1;
                     }
-
-                    // Skip last column
-                    neighbors++; src += offset + 1;
                 }
             }
 

--- a/Sources/Accord.Imaging/ObjectiveFidelity.cs
+++ b/Sources/Accord.Imaging/ObjectiveFidelity.cs
@@ -194,7 +194,7 @@ namespace Accord.Imaging
         /// <param name="a">The first image to be compared.</param>
         /// <param name="b">The second image that will be compared.</param>
         /// 
-        public unsafe void Compute(Bitmap a, Bitmap b)
+        public void Compute(Bitmap a, Bitmap b)
         {
             // lock source image
             BitmapData dataOriginal = a.LockBits(
@@ -218,7 +218,7 @@ namespace Accord.Imaging
         /// <param name="a">The first image to be compared.</param>
         /// <param name="b">The second image that will be compared.</param>
         /// 
-        public unsafe void Compute(BitmapData a, BitmapData b)
+        public void Compute(BitmapData a, BitmapData b)
         {
             Compute(new UnmanagedImage(a), new UnmanagedImage(b));
         }
@@ -230,7 +230,7 @@ namespace Accord.Imaging
         /// <param name="a">The first image to be compared.</param>
         /// <param name="b">The second image that will be compared.</param>
         /// 
-        public unsafe void Compute(UnmanagedImage a, UnmanagedImage b)
+        public void Compute(UnmanagedImage a, UnmanagedImage b)
         {
             // check image format
             if (!(a.PixelFormat == PixelFormat.Format8bppIndexed ||
@@ -260,39 +260,41 @@ namespace Accord.Imaging
             int stride = a.Stride;
             int offset = stride - a.Width * pixelSize;
 
-            byte* ptrA = (byte*)a.ImageData.ToPointer();
-            byte* ptrB = (byte*)b.ImageData.ToPointer();
-
-
             // Total error
             long sum = 0;
             double sumOfSquares = 0;
             double imageSumOfSquares = 0;
 
-
-            // Compute all metrics above
-            for (int y = 0; y < height; y++)
+            unsafe
             {
-                for (int x = 0; x < width; x++, ptrA++, ptrB++)
+                byte* ptrA = (byte*)a.ImageData.ToPointer();
+                byte* ptrB = (byte*)b.ImageData.ToPointer();
+
+
+                // Compute all metrics above
+                for (int y = 0; y < height; y++)
                 {
-                    long pA = *ptrA;
-                    long pB = *ptrB;
+                    for (int x = 0; x < width; x++, ptrA++, ptrB++)
+                    {
+                        long pA = *ptrA;
+                        long pB = *ptrB;
 
-                    long error = pB - pA;
-                    long square = error * error;
+                        long error = pB - pA;
+                        long square = error * error;
 
-                    // total error 
-                    sum += error;
+                        // total error 
+                        sum += error;
 
-                    // root mean square
-                    sumOfSquares += square;
+                        // root mean square
+                        sumOfSquares += square;
 
-                    // signal to noise ratio
-                    imageSumOfSquares += pB * pB;
+                        // signal to noise ratio
+                        imageSumOfSquares += pB * pB;
+                    }
+
+                    ptrA += offset;
+                    ptrB += offset;
                 }
-
-                ptrA += offset;
-                ptrB += offset;
             }
 
 

--- a/Sources/Accord.Imaging/Tools.cs
+++ b/Sources/Accord.Imaging/Tools.cs
@@ -581,7 +581,7 @@ namespace Accord.Imaging
         ///   Computes the sum of the pixels in a given image.
         /// </summary>
         /// 
-        public unsafe static int Sum(this BitmapData image)
+        public static int Sum(this BitmapData image)
         {
             return Sum(new UnmanagedImage(image));
         }
@@ -589,7 +589,7 @@ namespace Accord.Imaging
         /// <summary>
         ///   Computes the sum of the pixels in a given image.
         /// </summary>
-        public unsafe static int Sum(this UnmanagedImage image)
+        public static int Sum(this UnmanagedImage image)
         {
             if (image.PixelFormat != PixelFormat.Format8bppIndexed &&
                 image.PixelFormat != PixelFormat.Format16bppGrayScale)
@@ -601,26 +601,29 @@ namespace Accord.Imaging
 
             int sum = 0;
 
-            if (image.PixelFormat == PixelFormat.Format8bppIndexed)
+            unsafe
             {
-                byte* src = (byte*)image.ImageData.ToPointer();
-
-                for (int y = 0; y < height; y++)
+                if (image.PixelFormat == PixelFormat.Format8bppIndexed)
                 {
-                    for (int x = 0; x < width; x++, src++)
-                        sum += (*src);
-                    src += offset;
+                    byte* src = (byte*)image.ImageData.ToPointer();
+
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, src++)
+                            sum += (*src);
+                        src += offset;
+                    }
                 }
-            }
-            else
-            {
-                short* src = (short*)image.ImageData.ToPointer();
-
-                for (int y = 0; y < height; y++)
+                else
                 {
-                    for (int x = 0; x < width; x++, src++)
-                        sum += (*src);
-                    src += offset;
+                    short* src = (short*)image.ImageData.ToPointer();
+
+                    for (int y = 0; y < height; y++)
+                    {
+                        for (int x = 0; x < width; x++, src++)
+                            sum += (*src);
+                        src += offset;
+                    }
                 }
             }
 
@@ -655,7 +658,7 @@ namespace Accord.Imaging
         /// <summary>
         ///   Computes the sum of the pixels in a given image.
         /// </summary>
-        public unsafe static int Sum(this UnmanagedImage image, Rectangle rectangle)
+        public static int Sum(this UnmanagedImage image, Rectangle rectangle)
         {
             if ((image.PixelFormat != PixelFormat.Format8bppIndexed) &&
                 (image.PixelFormat != PixelFormat.Format16bppGrayScale))
@@ -671,28 +674,31 @@ namespace Accord.Imaging
             int ry = rectangle.Y;
             int sum = 0;
 
-            if (image.PixelFormat == PixelFormat.Format8bppIndexed)
+            unsafe
             {
-                byte* src = (byte*)image.ImageData.ToPointer();
-
-                for (int y = 0; y < rheight; y++)
+                if (image.PixelFormat == PixelFormat.Format8bppIndexed)
                 {
-                    byte* p = src + stride * (ry + y) + rx;
+                    byte* src = (byte*)image.ImageData.ToPointer();
 
-                    for (int x = 0; x < rwidth; x++)
-                        sum += (*p++);
+                    for (int y = 0; y < rheight; y++)
+                    {
+                        byte* p = src + stride * (ry + y) + rx;
+
+                        for (int x = 0; x < rwidth; x++)
+                            sum += (*p++);
+                    }
                 }
-            }
-            else
-            {
-                ushort* src = (ushort*)image.ImageData.ToPointer();
-
-                for (int y = 0; y < rheight; y++)
+                else
                 {
-                    ushort* p = src + stride * (ry + y) + rx;
+                    ushort* src = (ushort*)image.ImageData.ToPointer();
 
-                    for (int x = 0; x < rwidth; x++)
-                        sum += (*p++);
+                    for (int y = 0; y < rheight; y++)
+                    {
+                        ushort* p = src + stride * (ry + y) + rx;
+
+                        for (int x = 0; x < rwidth; x++)
+                            sum += (*p++);
+                    }
                 }
             }
 
@@ -786,7 +792,7 @@ namespace Accord.Imaging
         ///   Computes the standard deviation of image pixels.
         /// </summary>
         /// 
-        public unsafe static double StandardDeviation(this UnmanagedImage image, double mean)
+        public static double StandardDeviation(this UnmanagedImage image, double mean)
         {
             if (image.PixelFormat != PixelFormat.Format8bppIndexed &&
                 image.PixelFormat != PixelFormat.Format16bppGrayScale)
@@ -798,32 +804,35 @@ namespace Accord.Imaging
 
             double sum = 0;
 
-            if (image.PixelFormat == PixelFormat.Format8bppIndexed)
+            unsafe
             {
-                byte* src = (byte*)image.ImageData.ToPointer();
-
-                for (int y = 0; y < height; y++)
+                if (image.PixelFormat == PixelFormat.Format8bppIndexed)
                 {
-                    for (int x = 0; x < width; x++, src++)
+                    byte* src = (byte*)image.ImageData.ToPointer();
+
+                    for (int y = 0; y < height; y++)
                     {
-                        double u = (*src) - mean;
-                        sum += u * u;
+                        for (int x = 0; x < width; x++, src++)
+                        {
+                            double u = (*src) - mean;
+                            sum += u * u;
+                        }
+                        src += offset;
                     }
-                    src += offset;
                 }
-            }
-            else
-            {
-                short* src = (short*)image.ImageData.ToPointer();
-
-                for (int y = 0; y < height; y++)
+                else
                 {
-                    for (int x = 0; x < width; x++, src++)
+                    short* src = (short*)image.ImageData.ToPointer();
+
+                    for (int y = 0; y < height; y++)
                     {
-                        double u = (*src) - mean;
-                        sum += u * u;
+                        for (int x = 0; x < width; x++, src++)
+                        {
+                            double u = (*src) - mean;
+                            sum += u * u;
+                        }
+                        src += offset;
                     }
-                    src += offset;
                 }
             }
 
@@ -859,7 +868,7 @@ namespace Accord.Imaging
         ///   Computes the standard deviation of image pixels.
         /// </summary>
         /// 
-        public unsafe static double StandardDeviation(this UnmanagedImage image, Rectangle rectangle, double mean)
+        public static double StandardDeviation(this UnmanagedImage image, Rectangle rectangle, double mean)
         {
             if (image.PixelFormat != PixelFormat.Format8bppIndexed &&
                 image.PixelFormat != PixelFormat.Format16bppGrayScale)
@@ -877,36 +886,39 @@ namespace Accord.Imaging
 
             double sum = 0;
 
-            if (image.PixelFormat == PixelFormat.Format8bppIndexed)
+            unsafe
             {
-                byte* src = (byte*)image.ImageData.ToPointer();
-
-                for (int y = 0; y < rheight; y++)
+                if (image.PixelFormat == PixelFormat.Format8bppIndexed)
                 {
-                    byte* p = src + stride * (ry + y) + rx;
+                    byte* src = (byte*)image.ImageData.ToPointer();
 
-                    for (int x = 0; x < rwidth; x++)
+                    for (int y = 0; y < rheight; y++)
                     {
-                        double u = (*p++) - mean;
-                        sum += u * u;
+                        byte* p = src + stride * (ry + y) + rx;
+
+                        for (int x = 0; x < rwidth; x++)
+                        {
+                            double u = (*p++) - mean;
+                            sum += u * u;
+                        }
+                        src += offset;
                     }
-                    src += offset;
                 }
-            }
-            else
-            {
-                short* src = (short*)image.ImageData.ToPointer();
-
-                for (int y = 0; y < rheight; y++)
+                else
                 {
-                    short* p = src + stride * (ry + y) + rx;
+                    short* src = (short*)image.ImageData.ToPointer();
 
-                    for (int x = 0; x < rwidth; x++)
+                    for (int y = 0; y < rheight; y++)
                     {
-                        double u = (*p++) - mean;
-                        sum += u * u;
+                        short* p = src + stride * (ry + y) + rx;
+
+                        for (int x = 0; x < rwidth; x++)
+                        {
+                            double u = (*p++) - mean;
+                            sum += u * u;
+                        }
+                        src += offset;
                     }
-                    src += offset;
                 }
             }
 
@@ -974,7 +986,7 @@ namespace Accord.Imaging
         ///   Computes the maximum pixel value in the given image.
         /// </summary>
         /// 
-        public unsafe static int Max(this UnmanagedImage image, Rectangle rectangle)
+        public static int Max(this UnmanagedImage image, Rectangle rectangle)
         {
             if ((image.PixelFormat != PixelFormat.Format8bppIndexed) &&
                 (image.PixelFormat != PixelFormat.Format16bppGrayScale))
@@ -991,28 +1003,31 @@ namespace Accord.Imaging
 
             int max = 0;
 
-            if (image.PixelFormat == PixelFormat.Format8bppIndexed)
+            unsafe
             {
-                byte* src = (byte*)image.ImageData.ToPointer();
-
-                for (int y = 0; y < rheight; y++)
+                if (image.PixelFormat == PixelFormat.Format8bppIndexed)
                 {
-                    byte* p = src + stride * (ry + y) + rx;
+                    byte* src = (byte*)image.ImageData.ToPointer();
 
-                    for (int x = 0; x < rwidth; x++, p++)
-                        if (*p > max) max = *p;
+                    for (int y = 0; y < rheight; y++)
+                    {
+                        byte* p = src + stride * (ry + y) + rx;
+
+                        for (int x = 0; x < rwidth; x++, p++)
+                            if (*p > max) max = *p;
+                    }
                 }
-            }
-            else
-            {
-                ushort* src = (ushort*)image.ImageData.ToPointer();
-
-                for (int y = 0; y < rheight; y++)
+                else
                 {
-                    ushort* p = src + 2 * stride * (ry + y) + 2 * rx;
+                    ushort* src = (ushort*)image.ImageData.ToPointer();
 
-                    for (int x = 0; x < rwidth; x++, p++)
-                        if (*p > max) max = *p;
+                    for (int y = 0; y < rheight; y++)
+                    {
+                        ushort* p = src + 2 * stride * (ry + y) + 2 * rx;
+
+                        for (int x = 0; x < rwidth; x++, p++)
+                            if (*p > max) max = *p;
+                    }
                 }
             }
 
@@ -1023,7 +1038,7 @@ namespace Accord.Imaging
         ///   Computes the maximum pixel value in the given image.
         /// </summary>
         /// 
-        public unsafe static int Max(this UnmanagedImage image)
+        public static int Max(this UnmanagedImage image)
         {
             if ((image.PixelFormat != PixelFormat.Format8bppIndexed) &&
                 (image.PixelFormat != PixelFormat.Format16bppGrayScale))
@@ -1035,21 +1050,24 @@ namespace Accord.Imaging
 
             int max = 0;
 
-            if (image.PixelFormat == PixelFormat.Format8bppIndexed)
+            unsafe
             {
-                byte* src = (byte*)image.ImageData.ToPointer();
+                if (image.PixelFormat == PixelFormat.Format8bppIndexed)
+                {
+                    byte* src = (byte*)image.ImageData.ToPointer();
 
-                for (int y = 0; y < height; y++)
-                    for (int x = 0; x < width; x++, src++)
-                        if (*src > max) max = *src;
-            }
-            else
-            {
-                ushort* src = (ushort*)image.ImageData.ToPointer();
+                    for (int y = 0; y < height; y++)
+                        for (int x = 0; x < width; x++, src++)
+                            if (*src > max) max = *src;
+                }
+                else
+                {
+                    ushort* src = (ushort*)image.ImageData.ToPointer();
 
-                for (int y = 0; y < height; y++)
-                    for (int x = 0; x < width; x++, src++)
-                        if (*src > max) max = *src;
+                    for (int y = 0; y < height; y++)
+                        for (int x = 0; x < width; x++, src++)
+                            if (*src > max) max = *src;
+                }
             }
 
             return max;
@@ -1059,7 +1077,7 @@ namespace Accord.Imaging
         ///   Computes the maximum pixel value in the given image.
         /// </summary>
         /// 
-        public unsafe static int Max(this UnmanagedImage image, int channel)
+        public static int Max(this UnmanagedImage image, int channel)
         {
             if ((image.PixelFormat != PixelFormat.Format32bppArgb) &&
                 (image.PixelFormat != PixelFormat.Format24bppRgb))
@@ -1072,11 +1090,14 @@ namespace Accord.Imaging
 
             int max = 0;
 
-            byte* src = (byte*)image.ImageData.ToPointer() + channel;
+            unsafe
+            {
+                byte* src = (byte*)image.ImageData.ToPointer() + channel;
 
-            for (int y = 0; y < height; y++)
-                for (int x = 0; x < width; x++, src += pixelSize)
-                    if (*src > max) max = *src;
+                for (int y = 0; y < height; y++)
+                    for (int x = 0; x < width; x++, src += pixelSize)
+                        if (*src > max) max = *src;
+            }
 
 
             return max;
@@ -1086,7 +1107,7 @@ namespace Accord.Imaging
         ///   Computes the maximum pixel value in the given image.
         /// </summary>
         /// 
-        public unsafe static int Min(this UnmanagedImage image, int channel)
+        public static int Min(this UnmanagedImage image, int channel)
         {
             if ((image.PixelFormat != PixelFormat.Format32bppArgb) &&
                 (image.PixelFormat != PixelFormat.Format24bppRgb))
@@ -1099,12 +1120,14 @@ namespace Accord.Imaging
 
             int min = int.MaxValue;
 
-            byte* src = (byte*)image.ImageData.ToPointer() + channel;
+            unsafe
+            {
+                byte* src = (byte*)image.ImageData.ToPointer() + channel;
 
-            for (int y = 0; y < height; y++)
-                for (int x = 0; x < width; x++, src += pixelSize)
-                    if (*src < min) min = *src;
-
+                for (int y = 0; y < height; y++)
+                    for (int x = 0; x < width; x++, src += pixelSize)
+                        if (*src < min) min = *src;
+            }
 
             return min;
         }

--- a/Sources/Accord.Math/Decompositions/SingularValueDecomposition.cs
+++ b/Sources/Accord.Math/Decompositions/SingularValueDecomposition.cs
@@ -342,7 +342,7 @@ namespace Accord.Math.Decompositions
         ///   <paramref name="value"/> will be destroyed in the process, resulting in less
         ///   memory comsumption.</param>
         /// 
-        public unsafe SingularValueDecomposition(Double[,] value,
+        public SingularValueDecomposition(Double[,] value,
            bool computeLeftSingularVectors, bool computeRightSingularVectors, bool autoTranspose, bool inPlace)
         {
             if (value == null)
@@ -405,546 +405,549 @@ namespace Accord.Math.Decompositions
             bool wantu = computeLeftSingularVectors;
             bool wantv = computeRightSingularVectors;
 
-            fixed (Double* U = u)
-            fixed (Double* V = v)
-            fixed (Double* A = a)
+            unsafe
             {
-
-                // Will store ordered sequence of indices after sorting.
-                si = new int[ni]; for (int i = 0; i < ni; i++) si[i] = i;
-
-
-                // Reduce A to bidiagonal form, storing the diagonal elements in s and the super-diagonal elements in e.
-                int nct = System.Math.Min(m - 1, n);
-                int nrt = System.Math.Max(0, System.Math.Min(n - 2, m));
-				int mrc = System.Math.Max(nct, nrt);
-
-                for (int k = 0; k < mrc; k++)
+                fixed (Double* U = u)
+                fixed (Double* V = v)
+                fixed (Double* A = a)
                 {
-                    if (k < nct)
+
+                    // Will store ordered sequence of indices after sorting.
+                    si = new int[ni]; for (int i = 0; i < ni; i++) si[i] = i;
+
+
+                    // Reduce A to bidiagonal form, storing the diagonal elements in s and the super-diagonal elements in e.
+                    int nct = System.Math.Min(m - 1, n);
+                    int nrt = System.Math.Max(0, System.Math.Min(n - 2, m));
+				    int mrc = System.Math.Max(nct, nrt);
+
+                    for (int k = 0; k < mrc; k++)
                     {
-                        // Compute the transformation for the k-th column and place the k-th diagonal in s[k].
-                        // Compute 2-norm of k-th column without under/overflow.
-                        s[k] = 0;
-                        for (int i = k; i < m; i++)
-                            s[k] = Accord.Math.Tools.Hypotenuse(s[k], a[i, k]);
-
-                        if (s[k] != 0)
+                        if (k < nct)
                         {
-                            if (a[k, k] < 0)
-                                s[k] = -s[k];
-
+                            // Compute the transformation for the k-th column and place the k-th diagonal in s[k].
+                            // Compute 2-norm of k-th column without under/overflow.
+                            s[k] = 0;
                             for (int i = k; i < m; i++)
-                                a[i, k] /= s[k];
+                                s[k] = Accord.Math.Tools.Hypotenuse(s[k], a[i, k]);
 
-                            a[k, k] += 1;
-                        }
-
-                        s[k] = -s[k];
-                    }
-
-                    for (int j = k + 1; j < n; j++)
-                    {
-                        Double* ptr_ak = A + k * n + k; // A[k,k]
-                        Double* ptr_aj = A + k * n + j; // A[k,j]
-
-                        if ((k < nct) & (s[k] != 0))
-                        {
-                            // Apply the transformation.
-                            Double t = 0;
-                            Double* ak = ptr_ak;
-                            Double* aj = ptr_aj;
-
-                            for (int i = k; i < m; i++)
+                            if (s[k] != 0)
                             {
-                                t += (*ak) * (*aj);
-                                ak += n; aj += n;
+                                if (a[k, k] < 0)
+                                    s[k] = -s[k];
+
+                                for (int i = k; i < m; i++)
+                                    a[i, k] /= s[k];
+
+                                a[k, k] += 1;
                             }
 
-                            t = -t / *ptr_ak;
-                            ak = ptr_ak;
-                            aj = ptr_aj;
-
-                            for (int i = k; i < m; i++)
-                            {
-                                *aj += t * (*ak);
-                                ak += n; aj += n;
-                            }
+                            s[k] = -s[k];
                         }
 
-                        // Place the k-th row of A into e for the subsequent calculation of the row transformation.
-                        e[j] = *ptr_aj;
-                    }
-
-
-                    if (wantu & (k < nct))
-                    {
-                        // Place the transformation in U for subsequent back
-                        // multiplication.
-                        for (int i = k; i < m; i++)
-                            u[i, k] = a[i, k];
-                    }
-
-                    if (k < nrt)
-                    {
-                        // Compute the k-th row transformation and place the k-th super-diagonal in e[k].
-                        // Compute 2-norm without under/overflow.
-                        e[k] = 0;
-                        for (int i = k + 1; i < n; i++)
-                            e[k] = Accord.Math.Tools.Hypotenuse(e[k], e[i]);
-
-                        if (e[k] != 0)
+                        for (int j = k + 1; j < n; j++)
                         {
-                            if (e[k + 1] < 0)
-                                e[k] = -e[k];
+                            Double* ptr_ak = A + k * n + k; // A[k,k]
+                            Double* ptr_aj = A + k * n + j; // A[k,j]
 
-                            for (int i = k + 1; i < n; i++)
-                                e[i] /= e[k];
-
-                            e[k + 1] += 1;
-                        }
-
-                        e[k] = -e[k];
-                        if ((k + 1 < m) & (e[k] != 0))
-                        {
-                            // Apply the transformation.
-                            for (int i = k + 1; i < m; i++)
-                                work[i] = 0;
-
-                            int k1 = k + 1;
-                            for (int i = k1; i < m; i++)
+                            if ((k < nct) & (s[k] != 0))
                             {
-                                Double* ai = A + (i * n) + k1;
-                                for (int j = k1; j < n; j++, ai++)
-                                    work[i] += e[j] * (*ai);
-                            }
-
-                            for (int j = k1; j < n; j++)
-                            {
-                                Double t = -e[j] / e[k1];
-                                Double* aj = A + (k1 * n) + j;
-                                for (int i = k1; i < m; i++, aj += n)
-                                    *aj += t * work[i];
-                            }
-                        }
-
-                        if (wantv)
-                        {
-                            // Place the transformation in V for subsequent back multiplication.
-                            for (int i = k + 1; i < n; i++)
-                                v[i, k] = e[i];
-                        }
-                    }
-                }
-
-                // Set up the final bidiagonal matrix or order p.
-                int p = System.Math.Min(n, m + 1);
-                if (nct < n) s[nct] = a[nct, nct];
-                if (m < p) s[p - 1] = 0;
-                if (nrt + 1 < p) e[nrt] = a[nrt, p - 1];
-                e[p - 1] = 0;
-
-                // If required, generate U.
-                if (wantu)
-                {
-                    for (int j = nct; j < nu; j++)
-                    {
-                        for (int i = 0; i < m; i++)
-                            u[i, j] = 0;
-                        u[j, j] = 1;
-                    }
-
-                    for (int k = nct - 1; k >= 0; k--)
-                    {
-                        if (s[k] != 0)
-                        {
-                            Double* ptr_uk = U + k * nu + k; // u[k,k]
-
-                            Double* uk, uj;
-                            for (int j = k + 1; j < nu; j++)
-                            {
-                                Double* ptr_uj = U + k * nu + j; // u[k,j]
-
+                                // Apply the transformation.
                                 Double t = 0;
-                                uk = ptr_uk;
-                                uj = ptr_uj;
+                                Double* ak = ptr_ak;
+                                Double* aj = ptr_aj;
 
                                 for (int i = k; i < m; i++)
                                 {
-                                    t += *uk * *uj;
-                                    uk += nu; uj += nu;
+                                    t += (*ak) * (*aj);
+                                    ak += n; aj += n;
                                 }
 
-                                t = -t / *ptr_uk;
+                                t = -t / *ptr_ak;
+                                ak = ptr_ak;
+                                aj = ptr_aj;
 
-                                uk = ptr_uk; uj = ptr_uj;
                                 for (int i = k; i < m; i++)
                                 {
-                                    *uj += t * (*uk);
-                                    uk += nu; uj += nu;
+                                    *aj += t * (*ak);
+                                    ak += n; aj += n;
                                 }
                             }
 
-                            uk = ptr_uk;
-                            for (int i = k; i < m; i++)
-                            {
-                                *uk = -(*uk);
-                                uk += nu;
-                            }
-
-                            u[k, k] = 1 + u[k, k];
-                            for (int i = 0; i < k - 1; i++)
-                                u[i, k] = 0;
+                            // Place the k-th row of A into e for the subsequent calculation of the row transformation.
+                            e[j] = *ptr_aj;
                         }
-                        else
+
+
+                        if (wantu & (k < nct))
+                        {
+                            // Place the transformation in U for subsequent back
+                            // multiplication.
+                            for (int i = k; i < m; i++)
+                                u[i, k] = a[i, k];
+                        }
+
+                        if (k < nrt)
+                        {
+                            // Compute the k-th row transformation and place the k-th super-diagonal in e[k].
+                            // Compute 2-norm without under/overflow.
+                            e[k] = 0;
+                            for (int i = k + 1; i < n; i++)
+                                e[k] = Accord.Math.Tools.Hypotenuse(e[k], e[i]);
+
+                            if (e[k] != 0)
+                            {
+                                if (e[k + 1] < 0)
+                                    e[k] = -e[k];
+
+                                for (int i = k + 1; i < n; i++)
+                                    e[i] /= e[k];
+
+                                e[k + 1] += 1;
+                            }
+
+                            e[k] = -e[k];
+                            if ((k + 1 < m) & (e[k] != 0))
+                            {
+                                // Apply the transformation.
+                                for (int i = k + 1; i < m; i++)
+                                    work[i] = 0;
+
+                                int k1 = k + 1;
+                                for (int i = k1; i < m; i++)
+                                {
+                                    Double* ai = A + (i * n) + k1;
+                                    for (int j = k1; j < n; j++, ai++)
+                                        work[i] += e[j] * (*ai);
+                                }
+
+                                for (int j = k1; j < n; j++)
+                                {
+                                    Double t = -e[j] / e[k1];
+                                    Double* aj = A + (k1 * n) + j;
+                                    for (int i = k1; i < m; i++, aj += n)
+                                        *aj += t * work[i];
+                                }
+                            }
+
+                            if (wantv)
+                            {
+                                // Place the transformation in V for subsequent back multiplication.
+                                for (int i = k + 1; i < n; i++)
+                                    v[i, k] = e[i];
+                            }
+                        }
+                    }
+
+                    // Set up the final bidiagonal matrix or order p.
+                    int p = System.Math.Min(n, m + 1);
+                    if (nct < n) s[nct] = a[nct, nct];
+                    if (m < p) s[p - 1] = 0;
+                    if (nrt + 1 < p) e[nrt] = a[nrt, p - 1];
+                    e[p - 1] = 0;
+
+                    // If required, generate U.
+                    if (wantu)
+                    {
+                        for (int j = nct; j < nu; j++)
                         {
                             for (int i = 0; i < m; i++)
-                                u[i, k] = 0;
-                            u[k, k] = 1;
+                                u[i, j] = 0;
+                            u[j, j] = 1;
+                        }
+
+                        for (int k = nct - 1; k >= 0; k--)
+                        {
+                            if (s[k] != 0)
+                            {
+                                Double* ptr_uk = U + k * nu + k; // u[k,k]
+
+                                Double* uk, uj;
+                                for (int j = k + 1; j < nu; j++)
+                                {
+                                    Double* ptr_uj = U + k * nu + j; // u[k,j]
+
+                                    Double t = 0;
+                                    uk = ptr_uk;
+                                    uj = ptr_uj;
+
+                                    for (int i = k; i < m; i++)
+                                    {
+                                        t += *uk * *uj;
+                                        uk += nu; uj += nu;
+                                    }
+
+                                    t = -t / *ptr_uk;
+
+                                    uk = ptr_uk; uj = ptr_uj;
+                                    for (int i = k; i < m; i++)
+                                    {
+                                        *uj += t * (*uk);
+                                        uk += nu; uj += nu;
+                                    }
+                                }
+
+                                uk = ptr_uk;
+                                for (int i = k; i < m; i++)
+                                {
+                                    *uk = -(*uk);
+                                    uk += nu;
+                                }
+
+                                u[k, k] = 1 + u[k, k];
+                                for (int i = 0; i < k - 1; i++)
+                                    u[i, k] = 0;
+                            }
+                            else
+                            {
+                                for (int i = 0; i < m; i++)
+                                    u[i, k] = 0;
+                                u[k, k] = 1;
+                            }
                         }
                     }
-                }
 
-                // If required, generate V.
-                if (wantv)
-                {
-                    for (int k = n - 1; k >= 0; k--)
+                    // If required, generate V.
+                    if (wantv)
                     {
-                        if ((k < nrt) & (e[k] != 0))
+                        for (int k = n - 1; k >= 0; k--)
                         {
-                            // TODO: The following is a pseudo correction to make SVD
-                            //  work on matrices with n > m (less rows than columns).
-
-                            // For the proper correction, compute the decomposition of the
-                            //  transpose of A and swap the left and right eigenvectors
-
-                            // Original line:
-                            //   for (int j = k + 1; j < nu; j++)
-                            // Pseudo correction:
-                            //   for (int j = k + 1; j < n; j++)
-
-                            for (int j = k + 1; j < n; j++) // pseudo-correction
+                            if ((k < nrt) & (e[k] != 0))
                             {
-                                Double* ptr_vk = V + (k + 1) * n + k; // v[k + 1, k]
-                                Double* ptr_vj = V + (k + 1) * n + j; // v[k + 1, j]
+                                // TODO: The following is a pseudo correction to make SVD
+                                //  work on matrices with n > m (less rows than columns).
 
-                                Double t = 0;
-                                Double* vk = ptr_vk;
-                                Double* vj = ptr_vj;
+                                // For the proper correction, compute the decomposition of the
+                                //  transpose of A and swap the left and right eigenvectors
 
-                                for (int i = k + 1; i < n; i++)
+                                // Original line:
+                                //   for (int j = k + 1; j < nu; j++)
+                                // Pseudo correction:
+                                //   for (int j = k + 1; j < n; j++)
+
+                                for (int j = k + 1; j < n; j++) // pseudo-correction
                                 {
-                                    t += *vk * *vj;
-                                    vk += n; vj += n;
-                                }
+                                    Double* ptr_vk = V + (k + 1) * n + k; // v[k + 1, k]
+                                    Double* ptr_vj = V + (k + 1) * n + j; // v[k + 1, j]
 
-                                t = -t / *ptr_vk;
+                                    Double t = 0;
+                                    Double* vk = ptr_vk;
+                                    Double* vj = ptr_vj;
 
-                                vk = ptr_vk; vj = ptr_vj;
-                                for (int i = k + 1; i < n; i++)
-                                {
-                                    *vj += t * (*vk);
-                                    vk += n; vj += n;
+                                    for (int i = k + 1; i < n; i++)
+                                    {
+                                        t += *vk * *vj;
+                                        vk += n; vj += n;
+                                    }
+
+                                    t = -t / *ptr_vk;
+
+                                    vk = ptr_vk; vj = ptr_vj;
+                                    for (int i = k + 1; i < n; i++)
+                                    {
+                                        *vj += t * (*vk);
+                                        vk += n; vj += n;
+                                    }
                                 }
+                            }
+
+                            for (int i = 0; i < n; i++)
+                                v[i, k] = 0;
+                            v[k, k] = 1;
+                        }
+                    }
+
+                    // Main iteration loop for the singular values.
+                    int pp = p - 1;
+                    int iter = 0;
+                    while (p > 0)
+                    {
+                        int k, kase;
+
+                        // Here is where a test for too many iterations would go.
+
+                        // This section of the program inspects for
+                        // negligible elements in the s and e arrays.  On
+                        // completion the variables kase and k are set as follows.
+
+                        // kase = 1     if s(p) and e[k-1] are negligible and k<p
+                        // kase = 2     if s(k) is negligible and k<p
+                        // kase = 3     if e[k-1] is negligible, k<p, and
+                        //              s(k), ..., s(p) are not negligible (qr step).
+                        // kase = 4     if e(p-1) is negligible (convergence).
+
+                        for (k = p - 2; k >= -1; k--)
+                        {
+                            if (k == -1)
+                                break;
+
+                            var alpha = tiny + eps * (System.Math.Abs(s[k]) + System.Math.Abs(s[k + 1]));
+
+                            if (System.Math.Abs(e[k]) <= alpha || Double.IsNaN(e[k]))
+                            {
+                                e[k] = 0;
+                                break;
                             }
                         }
 
-                        for (int i = 0; i < n; i++)
-                            v[i, k] = 0;
-                        v[k, k] = 1;
-                    }
-                }
-
-                // Main iteration loop for the singular values.
-                int pp = p - 1;
-                int iter = 0;
-                while (p > 0)
-                {
-                    int k, kase;
-
-                    // Here is where a test for too many iterations would go.
-
-                    // This section of the program inspects for
-                    // negligible elements in the s and e arrays.  On
-                    // completion the variables kase and k are set as follows.
-
-                    // kase = 1     if s(p) and e[k-1] are negligible and k<p
-                    // kase = 2     if s(k) is negligible and k<p
-                    // kase = 3     if e[k-1] is negligible, k<p, and
-                    //              s(k), ..., s(p) are not negligible (qr step).
-                    // kase = 4     if e(p-1) is negligible (convergence).
-
-                    for (k = p - 2; k >= -1; k--)
-                    {
-                        if (k == -1)
-                            break;
-
-                        var alpha = tiny + eps * (System.Math.Abs(s[k]) + System.Math.Abs(s[k + 1]));
-
-                        if (System.Math.Abs(e[k]) <= alpha || Double.IsNaN(e[k]))
+                        if (k == p - 2)
                         {
-                            e[k] = 0;
-                            break;
+                            kase = 4;
                         }
-                    }
-
-                    if (k == p - 2)
-                    {
-                        kase = 4;
-                    }
-                    else
-                    {
-                        int ks;
-                        for (ks = p - 1; ks >= k; ks--)
-                        {
-                            if (ks == k)
-                                break;
-
-                            Double t = (ks != p ? System.Math.Abs(e[ks]) : 0) +
-                                       (ks != k + 1 ? System.Math.Abs(e[ks - 1]) : 0);
-                            if (System.Math.Abs(s[ks]) <= tiny + eps * t)
-                            {
-                                s[ks] = 0;
-                                break;
-                            }
-                        }
-
-                        if (ks == k)
-                            kase = 3;
-                        else if (ks == p - 1)
-                            kase = 1;
                         else
                         {
-                            kase = 2;
-                            k = ks;
+                            int ks;
+                            for (ks = p - 1; ks >= k; ks--)
+                            {
+                                if (ks == k)
+                                    break;
+
+                                Double t = (ks != p ? System.Math.Abs(e[ks]) : 0) +
+                                           (ks != k + 1 ? System.Math.Abs(e[ks - 1]) : 0);
+                                if (System.Math.Abs(s[ks]) <= tiny + eps * t)
+                                {
+                                    s[ks] = 0;
+                                    break;
+                                }
+                            }
+
+                            if (ks == k)
+                                kase = 3;
+                            else if (ks == p - 1)
+                                kase = 1;
+                            else
+                            {
+                                kase = 2;
+                                k = ks;
+                            }
                         }
-                    }
 
-                    k++;
+                        k++;
 
-                    // Perform the task indicated by kase.
-                    switch (kase)
-                    {
-                        // Deflate negligible s(p).
-                        case 1:
-                            {
-                                Double f = e[p - 2];
-                                e[p - 2] = 0;
-                                for (int j = p - 2; j >= k; j--)
+                        // Perform the task indicated by kase.
+                        switch (kase)
+                        {
+                            // Deflate negligible s(p).
+                            case 1:
                                 {
-                                    Double t = Accord.Math.Tools.Hypotenuse(s[j], f);
-                                    Double cs = s[j] / t;
-                                    Double sn = f / t;
-                                    s[j] = t;
-                                    if (j != k)
+                                    Double f = e[p - 2];
+                                    e[p - 2] = 0;
+                                    for (int j = p - 2; j >= k; j--)
                                     {
-                                        f = -sn * e[j - 1];
-                                        e[j - 1] = cs * e[j - 1];
-                                    }
-
-                                    if (wantv)
-                                    {
-                                        for (int i = 0; i < n; i++)
+                                        Double t = Accord.Math.Tools.Hypotenuse(s[j], f);
+                                        Double cs = s[j] / t;
+                                        Double sn = f / t;
+                                        s[j] = t;
+                                        if (j != k)
                                         {
-                                            t = cs * v[i, j] + sn * v[i, p - 1];
-                                            v[i, p - 1] = -sn * v[i, j] + cs * v[i, p - 1];
-                                            v[i, j] = t;
+                                            f = -sn * e[j - 1];
+                                            e[j - 1] = cs * e[j - 1];
                                         }
-                                    }
-                                }
-                            }
-                            break;
 
-                        // Split at negligible s(k).
-                        case 2:
-                            {
-                                Double f = e[k - 1];
-                                e[k - 1] = 0;
-                                for (int j = k; j < p; j++)
-                                {
-                                    Double t = Accord.Math.Tools.Hypotenuse(s[j], f);
-                                    Double cs = s[j] / t;
-                                    Double sn = f / t;
-                                    s[j] = t;
-                                    f = -sn * e[j];
-                                    e[j] = cs * e[j];
-
-                                    if (wantu)
-                                    {
-                                        for (int i = 0; i < m; i++)
+                                        if (wantv)
                                         {
-                                            t = cs * u[i, j] + sn * u[i, k - 1];
-                                            u[i, k - 1] = -sn * u[i, j] + cs * u[i, k - 1];
-                                            u[i, j] = t;
-                                        }
-                                    }
-                                }
-                            }
-                            break;
-
-                        // Perform one qr step.
-                        case 3:
-                            {
-                                // Calculate the shift.
-                                Double scale = System.Math.Max(System.Math.Max(System.Math.Max(System.Math.Max(System.Math.Abs(s[p - 1]), System.Math.Abs(s[p - 2])), System.Math.Abs(e[p - 2])), System.Math.Abs(s[k])), System.Math.Abs(e[k]));
-                                Double sp = s[p - 1] / scale;
-                                Double spm1 = s[p - 2] / scale;
-                                Double epm1 = e[p - 2] / scale;
-                                Double sk = s[k] / scale;
-                                Double ek = e[k] / scale;
-                                Double b = ((spm1 + sp) * (spm1 - sp) + epm1 * epm1) / 2;
-                                Double c = (sp * epm1) * (sp * epm1);
-                                double shift = 0;
-
-                                if ((b != 0) | (c != 0))
-                                {
-                                    if (b < 0)
-                                        shift = -System.Math.Sqrt(b * b + c);
-                                    else
-                                        shift = System.Math.Sqrt(b * b + c);
-
-                                    shift = c / (b + shift);
-                                }
-
-                                Double f = (sk + sp) * (sk - sp) + (Double)shift;
-                                Double g = sk * ek;
-
-                                // Chase zeros.
-                                for (int j = k; j < p - 1; j++)
-                                {
-                                    Double t = Accord.Math.Tools.Hypotenuse(f, g);
-                                    Double cs = f / t;
-                                    Double sn = g / t;
-                                    if (j != k) e[j - 1] = t;
-                                    f = cs * s[j] + sn * e[j];
-                                    e[j] = cs * e[j] - sn * s[j];
-                                    g = sn * s[j + 1];
-                                    s[j + 1] = cs * s[j + 1];
-
-                                    if (wantv)
-                                    {
-                                        unsafe
-                                        {
-                                            fixed (Double* ptr_vj = &v[0, j])
+                                            for (int i = 0; i < n; i++)
                                             {
-                                                Double* vj = ptr_vj;
-                                                Double* vj1 = ptr_vj + 1;
+                                                t = cs * v[i, j] + sn * v[i, p - 1];
+                                                v[i, p - 1] = -sn * v[i, j] + cs * v[i, p - 1];
+                                                v[i, j] = t;
+                                            }
+                                        }
+                                    }
+                                }
+                                break;
 
-                                                for (int i = 0; i < n; i++)
+                            // Split at negligible s(k).
+                            case 2:
+                                {
+                                    Double f = e[k - 1];
+                                    e[k - 1] = 0;
+                                    for (int j = k; j < p; j++)
+                                    {
+                                        Double t = Accord.Math.Tools.Hypotenuse(s[j], f);
+                                        Double cs = s[j] / t;
+                                        Double sn = f / t;
+                                        s[j] = t;
+                                        f = -sn * e[j];
+                                        e[j] = cs * e[j];
+
+                                        if (wantu)
+                                        {
+                                            for (int i = 0; i < m; i++)
+                                            {
+                                                t = cs * u[i, j] + sn * u[i, k - 1];
+                                                u[i, k - 1] = -sn * u[i, j] + cs * u[i, k - 1];
+                                                u[i, j] = t;
+                                            }
+                                        }
+                                    }
+                                }
+                                break;
+
+                            // Perform one qr step.
+                            case 3:
+                                {
+                                    // Calculate the shift.
+                                    Double scale = System.Math.Max(System.Math.Max(System.Math.Max(System.Math.Max(System.Math.Abs(s[p - 1]), System.Math.Abs(s[p - 2])), System.Math.Abs(e[p - 2])), System.Math.Abs(s[k])), System.Math.Abs(e[k]));
+                                    Double sp = s[p - 1] / scale;
+                                    Double spm1 = s[p - 2] / scale;
+                                    Double epm1 = e[p - 2] / scale;
+                                    Double sk = s[k] / scale;
+                                    Double ek = e[k] / scale;
+                                    Double b = ((spm1 + sp) * (spm1 - sp) + epm1 * epm1) / 2;
+                                    Double c = (sp * epm1) * (sp * epm1);
+                                    double shift = 0;
+
+                                    if ((b != 0) | (c != 0))
+                                    {
+                                        if (b < 0)
+                                            shift = -System.Math.Sqrt(b * b + c);
+                                        else
+                                            shift = System.Math.Sqrt(b * b + c);
+
+                                        shift = c / (b + shift);
+                                    }
+
+                                    Double f = (sk + sp) * (sk - sp) + (Double)shift;
+                                    Double g = sk * ek;
+
+                                    // Chase zeros.
+                                    for (int j = k; j < p - 1; j++)
+                                    {
+                                        Double t = Accord.Math.Tools.Hypotenuse(f, g);
+                                        Double cs = f / t;
+                                        Double sn = g / t;
+                                        if (j != k) e[j - 1] = t;
+                                        f = cs * s[j] + sn * e[j];
+                                        e[j] = cs * e[j] - sn * s[j];
+                                        g = sn * s[j + 1];
+                                        s[j + 1] = cs * s[j + 1];
+
+                                        if (wantv)
+                                        {
+                                            unsafe
+                                            {
+                                                fixed (Double* ptr_vj = &v[0, j])
                                                 {
-                                                    /*t = cs * v[i, j] + sn * v[i, j + 1];
-                                                    v[i, j + 1] = -sn * v[i, j] + cs * v[i, j + 1];
-                                                    v[i, j] = t;*/
+                                                    Double* vj = ptr_vj;
+                                                    Double* vj1 = ptr_vj + 1;
 
-                                                    Double vij = *vj;
-                                                    Double vij1 = *vj1;
+                                                    for (int i = 0; i < n; i++)
+                                                    {
+                                                        /*t = cs * v[i, j] + sn * v[i, j + 1];
+                                                        v[i, j + 1] = -sn * v[i, j] + cs * v[i, j + 1];
+                                                        v[i, j] = t;*/
 
-                                                    t = cs * vij + sn * vij1;
-                                                    *vj1 = -sn * vij + cs * vij1;
-                                                    *vj = t;
+                                                        Double vij = *vj;
+                                                        Double vij1 = *vj1;
 
-                                                    vj += n; vj1 += n;
+                                                        t = cs * vij + sn * vij1;
+                                                        *vj1 = -sn * vij + cs * vij1;
+                                                        *vj = t;
+
+                                                        vj += n; vj1 += n;
+                                                    }
                                                 }
                                             }
                                         }
-                                    }
 
-                                    t = Accord.Math.Tools.Hypotenuse(f, g);
-                                    cs = f / t;
-                                    sn = g / t;
-                                    s[j] = t;
-                                    f = cs * e[j] + sn * s[j + 1];
-                                    s[j + 1] = -sn * e[j] + cs * s[j + 1];
-                                    g = sn * e[j + 1];
-                                    e[j + 1] = cs * e[j + 1];
+                                        t = Accord.Math.Tools.Hypotenuse(f, g);
+                                        cs = f / t;
+                                        sn = g / t;
+                                        s[j] = t;
+                                        f = cs * e[j] + sn * s[j + 1];
+                                        s[j + 1] = -sn * e[j] + cs * s[j + 1];
+                                        g = sn * e[j + 1];
+                                        e[j + 1] = cs * e[j + 1];
 
-                                    if (wantu && (j < m - 1))
-                                    {
-                                        fixed (Double* ptr_uj = &u[0, j])
+                                        if (wantu && (j < m - 1))
                                         {
-                                            Double* uj = ptr_uj;
-                                            Double* uj1 = ptr_uj + 1;
-
-                                            for (int i = 0; i < m; i++)
+                                            fixed (Double* ptr_uj = &u[0, j])
                                             {
-                                                /* t = cs * u[i, j] + sn * u[i, j + 1];
-                                                 u[i, j + 1] = -sn * u[i, j] + cs * u[i, j + 1];
-                                                 u[i, j] = t;*/
+                                                Double* uj = ptr_uj;
+                                                Double* uj1 = ptr_uj + 1;
 
-                                                Double uij = *uj;
-                                                Double uij1 = *uj1;
+                                                for (int i = 0; i < m; i++)
+                                                {
+                                                    /* t = cs * u[i, j] + sn * u[i, j + 1];
+                                                     u[i, j + 1] = -sn * u[i, j] + cs * u[i, j + 1];
+                                                     u[i, j] = t;*/
 
-                                                t = cs * uij + sn * uij1;
-                                                *uj1 = -sn * uij + cs * uij1;
-                                                *uj = t;
+                                                    Double uij = *uj;
+                                                    Double uij1 = *uj1;
 
-                                                uj += nu; uj1 += nu;
+                                                    t = cs * uij + sn * uij1;
+                                                    *uj1 = -sn * uij + cs * uij1;
+                                                    *uj = t;
+
+                                                    uj += nu; uj1 += nu;
+                                                }
                                             }
                                         }
+
                                     }
 
+                                    e[p - 2] = f;
+                                    iter = iter + 1;
                                 }
+                                break;
 
-                                e[p - 2] = f;
-                                iter = iter + 1;
-                            }
-                            break;
-
-                        // Convergence.
-                        case 4:
-                            {
-                                // Make the singular values positive.
-                                if (s[k] <= 0)
+                            // Convergence.
+                            case 4:
                                 {
-                                    s[k] = (s[k] < 0 ? -s[k] : 0);
-                                    if (wantv)
+                                    // Make the singular values positive.
+                                    if (s[k] <= 0)
                                     {
-                                        for (int i = 0; i <= pp; i++)
-                                            v[i, k] = -v[i, k];
-                                    }
-                                }
-
-                                // Order the singular values.
-                                while (k < pp)
-                                {
-                                    if (s[k] >= s[k + 1])
-                                        break;
-
-                                    Double t = s[k];
-                                    s[k] = s[k + 1];
-                                    s[k + 1] = t;
-
-                                    int ti = si[k];
-                                    si[k] = si[k + 1];
-                                    si[k + 1] = ti;
-
-                                    if (wantv && (k < n - 1))
-                                    {
-                                        for (int i = 0; i < n; i++)
+                                        s[k] = (s[k] < 0 ? -s[k] : 0);
+                                        if (wantv)
                                         {
-                                            t = v[i, k + 1];
-                                            v[i, k + 1] = v[i, k];
-                                            v[i, k] = t;
+                                            for (int i = 0; i <= pp; i++)
+                                                v[i, k] = -v[i, k];
                                         }
                                     }
 
-                                    if (wantu && (k < m - 1))
+                                    // Order the singular values.
+                                    while (k < pp)
                                     {
-                                        for (int i = 0; i < m; i++)
+                                        if (s[k] >= s[k + 1])
+                                            break;
+
+                                        Double t = s[k];
+                                        s[k] = s[k + 1];
+                                        s[k + 1] = t;
+
+                                        int ti = si[k];
+                                        si[k] = si[k + 1];
+                                        si[k + 1] = ti;
+
+                                        if (wantv && (k < n - 1))
                                         {
-                                            t = u[i, k + 1];
-                                            u[i, k + 1] = u[i, k];
-                                            u[i, k] = t;
+                                            for (int i = 0; i < n; i++)
+                                            {
+                                                t = v[i, k + 1];
+                                                v[i, k + 1] = v[i, k];
+                                                v[i, k] = t;
+                                            }
                                         }
+
+                                        if (wantu && (k < m - 1))
+                                        {
+                                            for (int i = 0; i < m; i++)
+                                            {
+                                                t = u[i, k + 1];
+                                                u[i, k + 1] = u[i, k];
+                                                u[i, k] = t;
+                                            }
+                                        }
+
+                                        k++;
                                     }
 
-                                    k++;
+                                    iter = 0;
+                                    p--;
                                 }
-
-                                iter = 0;
-                                p--;
-                            }
-                            break;
+                                break;
+                        }
                     }
                 }
             }

--- a/Sources/Accord.Math/Decompositions/SingularValueDecomposition.tt
+++ b/Sources/Accord.Math/Decompositions/SingularValueDecomposition.tt
@@ -360,7 +360,7 @@ namespace Accord.Math.Decompositions
         ///   <paramref name="value"/> will be destroyed in the process, resulting in less
         ///   memory comsumption.</param>
         /// 
-        public unsafe SingularValueDecomposition<#=Suffix#>(<#=T#>[,] value,
+        public SingularValueDecomposition<#=Suffix#>(<#=T#>[,] value,
            bool computeLeftSingularVectors, bool computeRightSingularVectors, bool autoTranspose, bool inPlace)
         {
             if (value == null)
@@ -423,549 +423,552 @@ namespace Accord.Math.Decompositions
             bool wantu = computeLeftSingularVectors;
             bool wantv = computeRightSingularVectors;
 
-            fixed (<#=T#>* U = u)
-            fixed (<#=T#>* V = v)
-            fixed (<#=T#>* A = a)
-            {
-
-                // Will store ordered sequence of indices after sorting.
-                si = new int[ni]; for (int i = 0; i < ni; i++) si[i] = i;
-
-
-                // Reduce A to bidiagonal form, storing the diagonal elements in s and the super-diagonal elements in e.
-                int nct = System.Math.Min(m - 1, n);
-                int nrt = System.Math.Max(0, System.Math.Min(n - 2, m));
-				int mrc = System.Math.Max(nct, nrt);
-
-                for (int k = 0; k < mrc; k++)
-                {
-                    if (k < nct)
-                    {
-                        // Compute the transformation for the k-th column and place the k-th diagonal in s[k].
-                        // Compute 2-norm of k-th column without under/overflow.
-                        s[k] = 0;
-                        for (int i = k; i < m; i++)
-                            s[k] = Accord.Math.Tools.Hypotenuse(s[k], a[i, k]);
-
-                        if (s[k] != 0)
-                        {
-                            if (a[k, k] < 0)
-                                s[k] = -s[k];
-
-                            for (int i = k; i < m; i++)
-                                a[i, k] /= s[k];
-
-                            a[k, k] += 1;
-                        }
-
-                        s[k] = -s[k];
-                    }
-
-                    for (int j = k + 1; j < n; j++)
-                    {
-                        <#=T#>* ptr_ak = A + k * n + k; // A[k,k]
-                        <#=T#>* ptr_aj = A + k * n + j; // A[k,j]
-
-                        if ((k < nct) & (s[k] != 0))
-                        {
-                            // Apply the transformation.
-                            <#=T#> t = 0;
-                            <#=T#>* ak = ptr_ak;
-                            <#=T#>* aj = ptr_aj;
-
-                            for (int i = k; i < m; i++)
-                            {
-                                t += (*ak) * (*aj);
-                                ak += n; aj += n;
-                            }
-
-                            t = -t / *ptr_ak;
-                            ak = ptr_ak;
-                            aj = ptr_aj;
-
-                            for (int i = k; i < m; i++)
-                            {
-                                *aj += t * (*ak);
-                                ak += n; aj += n;
-                            }
-                        }
-
-                        // Place the k-th row of A into e for the subsequent calculation of the row transformation.
-                        e[j] = *ptr_aj;
-                    }
-
-
-                    if (wantu & (k < nct))
-                    {
-                        // Place the transformation in U for subsequent back
-                        // multiplication.
-                        for (int i = k; i < m; i++)
-                            u[i, k] = a[i, k];
-                    }
-
-                    if (k < nrt)
-                    {
-                        // Compute the k-th row transformation and place the k-th super-diagonal in e[k].
-                        // Compute 2-norm without under/overflow.
-                        e[k] = 0;
-                        for (int i = k + 1; i < n; i++)
-                            e[k] = Accord.Math.Tools.Hypotenuse(e[k], e[i]);
-
-                        if (e[k] != 0)
-                        {
-                            if (e[k + 1] < 0)
-                                e[k] = -e[k];
-
-                            for (int i = k + 1; i < n; i++)
-                                e[i] /= e[k];
-
-                            e[k + 1] += 1;
-                        }
-
-                        e[k] = -e[k];
-                        if ((k + 1 < m) & (e[k] != 0))
-                        {
-                            // Apply the transformation.
-                            for (int i = k + 1; i < m; i++)
-                                work[i] = 0;
-
-                            int k1 = k + 1;
-                            for (int i = k1; i < m; i++)
-                            {
-                                <#=T#>* ai = A + (i * n) + k1;
-                                for (int j = k1; j < n; j++, ai++)
-                                    work[i] += e[j] * (*ai);
-                            }
-
-                            for (int j = k1; j < n; j++)
-                            {
-                                <#=T#> t = -e[j] / e[k1];
-                                <#=T#>* aj = A + (k1 * n) + j;
-                                for (int i = k1; i < m; i++, aj += n)
-                                    *aj += t * work[i];
-                            }
-                        }
-
-                        if (wantv)
-                        {
-                            // Place the transformation in V for subsequent back multiplication.
-                            for (int i = k + 1; i < n; i++)
-                                v[i, k] = e[i];
-                        }
-                    }
-                }
-
-                // Set up the final bidiagonal matrix or order p.
-                int p = System.Math.Min(n, m + 1);
-                if (nct < n) s[nct] = a[nct, nct];
-                if (m < p) s[p - 1] = 0;
-                if (nrt + 1 < p) e[nrt] = a[nrt, p - 1];
-                e[p - 1] = 0;
-
-                // If required, generate U.
-                if (wantu)
-                {
-                    for (int j = nct; j < nu; j++)
-                    {
-                        for (int i = 0; i < m; i++)
-                            u[i, j] = 0;
-                        u[j, j] = 1;
-                    }
-
-                    for (int k = nct - 1; k >= 0; k--)
-                    {
-                        if (s[k] != 0)
-                        {
-                            <#=T#>* ptr_uk = U + k * nu + k; // u[k,k]
-
-                            <#=T#>* uk, uj;
-                            for (int j = k + 1; j < nu; j++)
-                            {
-                                <#=T#>* ptr_uj = U + k * nu + j; // u[k,j]
-
-                                <#=T#> t = 0;
-                                uk = ptr_uk;
-                                uj = ptr_uj;
-
-                                for (int i = k; i < m; i++)
-                                {
-                                    t += *uk * *uj;
-                                    uk += nu; uj += nu;
-                                }
-
-                                t = -t / *ptr_uk;
-
-                                uk = ptr_uk; uj = ptr_uj;
-                                for (int i = k; i < m; i++)
-                                {
-                                    *uj += t * (*uk);
-                                    uk += nu; uj += nu;
-                                }
-                            }
-
-                            uk = ptr_uk;
-                            for (int i = k; i < m; i++)
-                            {
-                                *uk = -(*uk);
-                                uk += nu;
-                            }
-
-                            u[k, k] = 1 + u[k, k];
-                            for (int i = 0; i < k - 1; i++)
-                                u[i, k] = 0;
-                        }
-                        else
-                        {
-                            for (int i = 0; i < m; i++)
-                                u[i, k] = 0;
-                            u[k, k] = 1;
-                        }
-                    }
-                }
-
-                // If required, generate V.
-                if (wantv)
-                {
-                    for (int k = n - 1; k >= 0; k--)
-                    {
-                        if ((k < nrt) & (e[k] != 0))
-                        {
-                            // TODO: The following is a pseudo correction to make SVD
-                            //  work on matrices with n > m (less rows than columns).
-
-                            // For the proper correction, compute the decomposition of the
-                            //  transpose of A and swap the left and right eigenvectors
-
-                            // Original line:
-                            //   for (int j = k + 1; j < nu; j++)
-                            // Pseudo correction:
-                            //   for (int j = k + 1; j < n; j++)
-
-                            for (int j = k + 1; j < n; j++) // pseudo-correction
-                            {
-                                <#=T#>* ptr_vk = V + (k + 1) * n + k; // v[k + 1, k]
-                                <#=T#>* ptr_vj = V + (k + 1) * n + j; // v[k + 1, j]
-
-                                <#=T#> t = 0;
-                                <#=T#>* vk = ptr_vk;
-                                <#=T#>* vj = ptr_vj;
-
-                                for (int i = k + 1; i < n; i++)
-                                {
-                                    t += *vk * *vj;
-                                    vk += n; vj += n;
-                                }
-
-                                t = -t / *ptr_vk;
-
-                                vk = ptr_vk; vj = ptr_vj;
-                                for (int i = k + 1; i < n; i++)
-                                {
-                                    *vj += t * (*vk);
-                                    vk += n; vj += n;
-                                }
-                            }
-                        }
-
-                        for (int i = 0; i < n; i++)
-                            v[i, k] = 0;
-                        v[k, k] = 1;
-                    }
-                }
-
-                // Main iteration loop for the singular values.
-                int pp = p - 1;
-                int iter = 0;
-                while (p > 0)
-                {
-                    int k, kase;
-
-                    // Here is where a test for too many iterations would go.
-
-                    // This section of the program inspects for
-                    // negligible elements in the s and e arrays.  On
-                    // completion the variables kase and k are set as follows.
-
-                    // kase = 1     if s(p) and e[k-1] are negligible and k<p
-                    // kase = 2     if s(k) is negligible and k<p
-                    // kase = 3     if e[k-1] is negligible, k<p, and
-                    //              s(k), ..., s(p) are not negligible (qr step).
-                    // kase = 4     if e(p-1) is negligible (convergence).
-
-                    for (k = p - 2; k >= -1; k--)
-                    {
-                        if (k == -1)
-                            break;
-
-                        var alpha = tiny + eps * (System.Math.Abs(s[k]) + System.Math.Abs(s[k + 1]));
-
-                        if (System.Math.Abs(e[k]) <= alpha || <#=T#>.IsNaN(e[k]))
-                        {
-                            e[k] = 0;
-                            break;
-                        }
-                    }
-
-                    if (k == p - 2)
-                    {
-                        kase = 4;
-                    }
-                    else
-                    {
-                        int ks;
-                        for (ks = p - 1; ks >= k; ks--)
-                        {
-                            if (ks == k)
-                                break;
-
-                            <#=T#> t = (ks != p ? System.Math.Abs(e[ks]) : 0) +
-                                       (ks != k + 1 ? System.Math.Abs(e[ks - 1]) : 0);
-                            if (System.Math.Abs(s[ks]) <= tiny + eps * t)
-                            {
-                                s[ks] = 0;
-                                break;
-                            }
-                        }
-
-                        if (ks == k)
-                            kase = 3;
-                        else if (ks == p - 1)
-                            kase = 1;
-                        else
-                        {
-                            kase = 2;
-                            k = ks;
-                        }
-                    }
-
-                    k++;
-
-                    // Perform the task indicated by kase.
-                    switch (kase)
-                    {
-                        // Deflate negligible s(p).
-                        case 1:
-                            {
-                                <#=T#> f = e[p - 2];
-                                e[p - 2] = 0;
-                                for (int j = p - 2; j >= k; j--)
-                                {
-                                    <#=T#> t = Accord.Math.Tools.Hypotenuse(s[j], f);
-                                    <#=T#> cs = s[j] / t;
-                                    <#=T#> sn = f / t;
-                                    s[j] = t;
-                                    if (j != k)
-                                    {
-                                        f = -sn * e[j - 1];
-                                        e[j - 1] = cs * e[j - 1];
-                                    }
-
-                                    if (wantv)
-                                    {
-                                        for (int i = 0; i < n; i++)
-                                        {
-                                            t = cs * v[i, j] + sn * v[i, p - 1];
-                                            v[i, p - 1] = -sn * v[i, j] + cs * v[i, p - 1];
-                                            v[i, j] = t;
-                                        }
-                                    }
-                                }
-                            }
-                            break;
-
-                        // Split at negligible s(k).
-                        case 2:
-                            {
-                                <#=T#> f = e[k - 1];
-                                e[k - 1] = 0;
-                                for (int j = k; j < p; j++)
-                                {
-                                    <#=T#> t = Accord.Math.Tools.Hypotenuse(s[j], f);
-                                    <#=T#> cs = s[j] / t;
-                                    <#=T#> sn = f / t;
-                                    s[j] = t;
-                                    f = -sn * e[j];
-                                    e[j] = cs * e[j];
-
-                                    if (wantu)
-                                    {
-                                        for (int i = 0; i < m; i++)
-                                        {
-                                            t = cs * u[i, j] + sn * u[i, k - 1];
-                                            u[i, k - 1] = -sn * u[i, j] + cs * u[i, k - 1];
-                                            u[i, j] = t;
-                                        }
-                                    }
-                                }
-                            }
-                            break;
-
-                        // Perform one qr step.
-                        case 3:
-                            {
-                                // Calculate the shift.
-                                <#=T#> scale = System.Math.Max(System.Math.Max(System.Math.Max(System.Math.Max(System.Math.Abs(s[p - 1]), System.Math.Abs(s[p - 2])), System.Math.Abs(e[p - 2])), System.Math.Abs(s[k])), System.Math.Abs(e[k]));
-                                <#=T#> sp = s[p - 1] / scale;
-                                <#=T#> spm1 = s[p - 2] / scale;
-                                <#=T#> epm1 = e[p - 2] / scale;
-                                <#=T#> sk = s[k] / scale;
-                                <#=T#> ek = e[k] / scale;
-                                <#=T#> b = ((spm1 + sp) * (spm1 - sp) + epm1 * epm1) / 2;
-                                <#=T#> c = (sp * epm1) * (sp * epm1);
-                                double shift = 0;
-
-                                if ((b != 0) | (c != 0))
-                                {
-                                    if (b < 0)
-                                        shift = -System.Math.Sqrt(b * b + c);
-                                    else
-                                        shift = System.Math.Sqrt(b * b + c);
-
-                                    shift = c / (b + shift);
-                                }
-
-                                <#=T#> f = (sk + sp) * (sk - sp) + (<#=T#>)shift;
-                                <#=T#> g = sk * ek;
-
-                                // Chase zeros.
-                                for (int j = k; j < p - 1; j++)
-                                {
-                                    <#=T#> t = Accord.Math.Tools.Hypotenuse(f, g);
-                                    <#=T#> cs = f / t;
-                                    <#=T#> sn = g / t;
-                                    if (j != k) e[j - 1] = t;
-                                    f = cs * s[j] + sn * e[j];
-                                    e[j] = cs * e[j] - sn * s[j];
-                                    g = sn * s[j + 1];
-                                    s[j + 1] = cs * s[j + 1];
-
-                                    if (wantv)
-                                    {
-                                        unsafe
-                                        {
-                                            fixed (<#=T#>* ptr_vj = &v[0, j])
-                                            {
-                                                <#=T#>* vj = ptr_vj;
-                                                <#=T#>* vj1 = ptr_vj + 1;
-
-                                                for (int i = 0; i < n; i++)
-                                                {
-                                                    /*t = cs * v[i, j] + sn * v[i, j + 1];
-                                                    v[i, j + 1] = -sn * v[i, j] + cs * v[i, j + 1];
-                                                    v[i, j] = t;*/
-
-                                                    <#=T#> vij = *vj;
-                                                    <#=T#> vij1 = *vj1;
-
-                                                    t = cs * vij + sn * vij1;
-                                                    *vj1 = -sn * vij + cs * vij1;
-                                                    *vj = t;
-
-                                                    vj += n; vj1 += n;
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    t = Accord.Math.Tools.Hypotenuse(f, g);
-                                    cs = f / t;
-                                    sn = g / t;
-                                    s[j] = t;
-                                    f = cs * e[j] + sn * s[j + 1];
-                                    s[j + 1] = -sn * e[j] + cs * s[j + 1];
-                                    g = sn * e[j + 1];
-                                    e[j + 1] = cs * e[j + 1];
-
-                                    if (wantu && (j < m - 1))
-                                    {
-                                        fixed (<#=T#>* ptr_uj = &u[0, j])
-                                        {
-                                            <#=T#>* uj = ptr_uj;
-                                            <#=T#>* uj1 = ptr_uj + 1;
-
-                                            for (int i = 0; i < m; i++)
-                                            {
-                                                /* t = cs * u[i, j] + sn * u[i, j + 1];
-                                                 u[i, j + 1] = -sn * u[i, j] + cs * u[i, j + 1];
-                                                 u[i, j] = t;*/
-
-                                                <#=T#> uij = *uj;
-                                                <#=T#> uij1 = *uj1;
-
-                                                t = cs * uij + sn * uij1;
-                                                *uj1 = -sn * uij + cs * uij1;
-                                                *uj = t;
-
-                                                uj += nu; uj1 += nu;
-                                            }
-                                        }
-                                    }
-
-                                }
-
-                                e[p - 2] = f;
-                                iter = iter + 1;
-                            }
-                            break;
-
-                        // Convergence.
-                        case 4:
-                            {
-                                // Make the singular values positive.
-                                if (s[k] <= 0)
-                                {
-                                    s[k] = (s[k] < 0 ? -s[k] : 0);
-                                    if (wantv)
-                                    {
-                                        for (int i = 0; i <= pp; i++)
-                                            v[i, k] = -v[i, k];
-                                    }
-                                }
-
-                                // Order the singular values.
-                                while (k < pp)
-                                {
-                                    if (s[k] >= s[k + 1])
-                                        break;
-
-                                    <#=T#> t = s[k];
-                                    s[k] = s[k + 1];
-                                    s[k + 1] = t;
-
-                                    int ti = si[k];
-                                    si[k] = si[k + 1];
-                                    si[k + 1] = ti;
-
-                                    if (wantv && (k < n - 1))
-                                    {
-                                        for (int i = 0; i < n; i++)
-                                        {
-                                            t = v[i, k + 1];
-                                            v[i, k + 1] = v[i, k];
-                                            v[i, k] = t;
-                                        }
-                                    }
-
-                                    if (wantu && (k < m - 1))
-                                    {
-                                        for (int i = 0; i < m; i++)
-                                        {
-                                            t = u[i, k + 1];
-                                            u[i, k + 1] = u[i, k];
-                                            u[i, k] = t;
-                                        }
-                                    }
-
-                                    k++;
-                                }
-
-                                iter = 0;
-                                p--;
-                            }
-                            break;
-                    }
-                }
-            }
+			unsafe
+			{
+				fixed (<#=T#>* U = u)
+				fixed (<#=T#>* V = v)
+				fixed (<#=T#>* A = a)
+				{
+
+					// Will store ordered sequence of indices after sorting.
+					si = new int[ni]; for (int i = 0; i < ni; i++) si[i] = i;
+
+
+					// Reduce A to bidiagonal form, storing the diagonal elements in s and the super-diagonal elements in e.
+					int nct = System.Math.Min(m - 1, n);
+					int nrt = System.Math.Max(0, System.Math.Min(n - 2, m));
+					int mrc = System.Math.Max(nct, nrt);
+
+					for (int k = 0; k < mrc; k++)
+					{
+						if (k < nct)
+						{
+							// Compute the transformation for the k-th column and place the k-th diagonal in s[k].
+							// Compute 2-norm of k-th column without under/overflow.
+							s[k] = 0;
+							for (int i = k; i < m; i++)
+								s[k] = Accord.Math.Tools.Hypotenuse(s[k], a[i, k]);
+
+							if (s[k] != 0)
+							{
+								if (a[k, k] < 0)
+									s[k] = -s[k];
+
+								for (int i = k; i < m; i++)
+									a[i, k] /= s[k];
+
+								a[k, k] += 1;
+							}
+
+							s[k] = -s[k];
+						}
+
+						for (int j = k + 1; j < n; j++)
+						{
+							<#=T#>* ptr_ak = A + k * n + k; // A[k,k]
+							<#=T#>* ptr_aj = A + k * n + j; // A[k,j]
+
+							if ((k < nct) & (s[k] != 0))
+							{
+								// Apply the transformation.
+								<#=T#> t = 0;
+								<#=T#>* ak = ptr_ak;
+								<#=T#>* aj = ptr_aj;
+
+								for (int i = k; i < m; i++)
+								{
+									t += (*ak) * (*aj);
+									ak += n; aj += n;
+								}
+
+								t = -t / *ptr_ak;
+								ak = ptr_ak;
+								aj = ptr_aj;
+
+								for (int i = k; i < m; i++)
+								{
+									*aj += t * (*ak);
+									ak += n; aj += n;
+								}
+							}
+
+							// Place the k-th row of A into e for the subsequent calculation of the row transformation.
+							e[j] = *ptr_aj;
+						}
+
+
+						if (wantu & (k < nct))
+						{
+							// Place the transformation in U for subsequent back
+							// multiplication.
+							for (int i = k; i < m; i++)
+								u[i, k] = a[i, k];
+						}
+
+						if (k < nrt)
+						{
+							// Compute the k-th row transformation and place the k-th super-diagonal in e[k].
+							// Compute 2-norm without under/overflow.
+							e[k] = 0;
+							for (int i = k + 1; i < n; i++)
+								e[k] = Accord.Math.Tools.Hypotenuse(e[k], e[i]);
+
+							if (e[k] != 0)
+							{
+								if (e[k + 1] < 0)
+									e[k] = -e[k];
+
+								for (int i = k + 1; i < n; i++)
+									e[i] /= e[k];
+
+								e[k + 1] += 1;
+							}
+
+							e[k] = -e[k];
+							if ((k + 1 < m) & (e[k] != 0))
+							{
+								// Apply the transformation.
+								for (int i = k + 1; i < m; i++)
+									work[i] = 0;
+
+								int k1 = k + 1;
+								for (int i = k1; i < m; i++)
+								{
+									<#=T#>* ai = A + (i * n) + k1;
+									for (int j = k1; j < n; j++, ai++)
+										work[i] += e[j] * (*ai);
+								}
+
+								for (int j = k1; j < n; j++)
+								{
+									<#=T#> t = -e[j] / e[k1];
+									<#=T#>* aj = A + (k1 * n) + j;
+									for (int i = k1; i < m; i++, aj += n)
+										*aj += t * work[i];
+								}
+							}
+
+							if (wantv)
+							{
+								// Place the transformation in V for subsequent back multiplication.
+								for (int i = k + 1; i < n; i++)
+									v[i, k] = e[i];
+							}
+						}
+					}
+
+					// Set up the final bidiagonal matrix or order p.
+					int p = System.Math.Min(n, m + 1);
+					if (nct < n) s[nct] = a[nct, nct];
+					if (m < p) s[p - 1] = 0;
+					if (nrt + 1 < p) e[nrt] = a[nrt, p - 1];
+					e[p - 1] = 0;
+
+					// If required, generate U.
+					if (wantu)
+					{
+						for (int j = nct; j < nu; j++)
+						{
+							for (int i = 0; i < m; i++)
+								u[i, j] = 0;
+							u[j, j] = 1;
+						}
+
+						for (int k = nct - 1; k >= 0; k--)
+						{
+							if (s[k] != 0)
+							{
+								<#=T#>* ptr_uk = U + k * nu + k; // u[k,k]
+
+								<#=T#>* uk, uj;
+								for (int j = k + 1; j < nu; j++)
+								{
+									<#=T#>* ptr_uj = U + k * nu + j; // u[k,j]
+
+									<#=T#> t = 0;
+									uk = ptr_uk;
+									uj = ptr_uj;
+
+									for (int i = k; i < m; i++)
+									{
+										t += *uk * *uj;
+										uk += nu; uj += nu;
+									}
+
+									t = -t / *ptr_uk;
+
+									uk = ptr_uk; uj = ptr_uj;
+									for (int i = k; i < m; i++)
+									{
+										*uj += t * (*uk);
+										uk += nu; uj += nu;
+									}
+								}
+
+								uk = ptr_uk;
+								for (int i = k; i < m; i++)
+								{
+									*uk = -(*uk);
+									uk += nu;
+								}
+
+								u[k, k] = 1 + u[k, k];
+								for (int i = 0; i < k - 1; i++)
+									u[i, k] = 0;
+							}
+							else
+							{
+								for (int i = 0; i < m; i++)
+									u[i, k] = 0;
+								u[k, k] = 1;
+							}
+						}
+					}
+
+					// If required, generate V.
+					if (wantv)
+					{
+						for (int k = n - 1; k >= 0; k--)
+						{
+							if ((k < nrt) & (e[k] != 0))
+							{
+								// TODO: The following is a pseudo correction to make SVD
+								//  work on matrices with n > m (less rows than columns).
+
+								// For the proper correction, compute the decomposition of the
+								//  transpose of A and swap the left and right eigenvectors
+
+								// Original line:
+								//   for (int j = k + 1; j < nu; j++)
+								// Pseudo correction:
+								//   for (int j = k + 1; j < n; j++)
+
+								for (int j = k + 1; j < n; j++) // pseudo-correction
+								{
+									<#=T#>* ptr_vk = V + (k + 1) * n + k; // v[k + 1, k]
+									<#=T#>* ptr_vj = V + (k + 1) * n + j; // v[k + 1, j]
+
+									<#=T#> t = 0;
+									<#=T#>* vk = ptr_vk;
+									<#=T#>* vj = ptr_vj;
+
+									for (int i = k + 1; i < n; i++)
+									{
+										t += *vk * *vj;
+										vk += n; vj += n;
+									}
+
+									t = -t / *ptr_vk;
+
+									vk = ptr_vk; vj = ptr_vj;
+									for (int i = k + 1; i < n; i++)
+									{
+										*vj += t * (*vk);
+										vk += n; vj += n;
+									}
+								}
+							}
+
+							for (int i = 0; i < n; i++)
+								v[i, k] = 0;
+							v[k, k] = 1;
+						}
+					}
+
+					// Main iteration loop for the singular values.
+					int pp = p - 1;
+					int iter = 0;
+					while (p > 0)
+					{
+						int k, kase;
+
+						// Here is where a test for too many iterations would go.
+
+						// This section of the program inspects for
+						// negligible elements in the s and e arrays.  On
+						// completion the variables kase and k are set as follows.
+
+						// kase = 1     if s(p) and e[k-1] are negligible and k<p
+						// kase = 2     if s(k) is negligible and k<p
+						// kase = 3     if e[k-1] is negligible, k<p, and
+						//              s(k), ..., s(p) are not negligible (qr step).
+						// kase = 4     if e(p-1) is negligible (convergence).
+
+						for (k = p - 2; k >= -1; k--)
+						{
+							if (k == -1)
+								break;
+
+							var alpha = tiny + eps * (System.Math.Abs(s[k]) + System.Math.Abs(s[k + 1]));
+
+							if (System.Math.Abs(e[k]) <= alpha || <#=T#>.IsNaN(e[k]))
+							{
+								e[k] = 0;
+								break;
+							}
+						}
+
+						if (k == p - 2)
+						{
+							kase = 4;
+						}
+						else
+						{
+							int ks;
+							for (ks = p - 1; ks >= k; ks--)
+							{
+								if (ks == k)
+									break;
+
+								<#=T#> t = (ks != p ? System.Math.Abs(e[ks]) : 0) +
+										   (ks != k + 1 ? System.Math.Abs(e[ks - 1]) : 0);
+								if (System.Math.Abs(s[ks]) <= tiny + eps * t)
+								{
+									s[ks] = 0;
+									break;
+								}
+							}
+
+							if (ks == k)
+								kase = 3;
+							else if (ks == p - 1)
+								kase = 1;
+							else
+							{
+								kase = 2;
+								k = ks;
+							}
+						}
+
+						k++;
+
+						// Perform the task indicated by kase.
+						switch (kase)
+						{
+							// Deflate negligible s(p).
+							case 1:
+								{
+									<#=T#> f = e[p - 2];
+									e[p - 2] = 0;
+									for (int j = p - 2; j >= k; j--)
+									{
+										<#=T#> t = Accord.Math.Tools.Hypotenuse(s[j], f);
+										<#=T#> cs = s[j] / t;
+										<#=T#> sn = f / t;
+										s[j] = t;
+										if (j != k)
+										{
+											f = -sn * e[j - 1];
+											e[j - 1] = cs * e[j - 1];
+										}
+
+										if (wantv)
+										{
+											for (int i = 0; i < n; i++)
+											{
+												t = cs * v[i, j] + sn * v[i, p - 1];
+												v[i, p - 1] = -sn * v[i, j] + cs * v[i, p - 1];
+												v[i, j] = t;
+											}
+										}
+									}
+								}
+								break;
+
+							// Split at negligible s(k).
+							case 2:
+								{
+									<#=T#> f = e[k - 1];
+									e[k - 1] = 0;
+									for (int j = k; j < p; j++)
+									{
+										<#=T#> t = Accord.Math.Tools.Hypotenuse(s[j], f);
+										<#=T#> cs = s[j] / t;
+										<#=T#> sn = f / t;
+										s[j] = t;
+										f = -sn * e[j];
+										e[j] = cs * e[j];
+
+										if (wantu)
+										{
+											for (int i = 0; i < m; i++)
+											{
+												t = cs * u[i, j] + sn * u[i, k - 1];
+												u[i, k - 1] = -sn * u[i, j] + cs * u[i, k - 1];
+												u[i, j] = t;
+											}
+										}
+									}
+								}
+								break;
+
+							// Perform one qr step.
+							case 3:
+								{
+									// Calculate the shift.
+									<#=T#> scale = System.Math.Max(System.Math.Max(System.Math.Max(System.Math.Max(System.Math.Abs(s[p - 1]), System.Math.Abs(s[p - 2])), System.Math.Abs(e[p - 2])), System.Math.Abs(s[k])), System.Math.Abs(e[k]));
+									<#=T#> sp = s[p - 1] / scale;
+									<#=T#> spm1 = s[p - 2] / scale;
+									<#=T#> epm1 = e[p - 2] / scale;
+									<#=T#> sk = s[k] / scale;
+									<#=T#> ek = e[k] / scale;
+									<#=T#> b = ((spm1 + sp) * (spm1 - sp) + epm1 * epm1) / 2;
+									<#=T#> c = (sp * epm1) * (sp * epm1);
+									double shift = 0;
+
+									if ((b != 0) | (c != 0))
+									{
+										if (b < 0)
+											shift = -System.Math.Sqrt(b * b + c);
+										else
+											shift = System.Math.Sqrt(b * b + c);
+
+										shift = c / (b + shift);
+									}
+
+									<#=T#> f = (sk + sp) * (sk - sp) + (<#=T#>)shift;
+									<#=T#> g = sk * ek;
+
+									// Chase zeros.
+									for (int j = k; j < p - 1; j++)
+									{
+										<#=T#> t = Accord.Math.Tools.Hypotenuse(f, g);
+										<#=T#> cs = f / t;
+										<#=T#> sn = g / t;
+										if (j != k) e[j - 1] = t;
+										f = cs * s[j] + sn * e[j];
+										e[j] = cs * e[j] - sn * s[j];
+										g = sn * s[j + 1];
+										s[j + 1] = cs * s[j + 1];
+
+										if (wantv)
+										{
+											unsafe
+											{
+												fixed (<#=T#>* ptr_vj = &v[0, j])
+												{
+													<#=T#>* vj = ptr_vj;
+													<#=T#>* vj1 = ptr_vj + 1;
+
+													for (int i = 0; i < n; i++)
+													{
+														/*t = cs * v[i, j] + sn * v[i, j + 1];
+														v[i, j + 1] = -sn * v[i, j] + cs * v[i, j + 1];
+														v[i, j] = t;*/
+
+														<#=T#> vij = *vj;
+														<#=T#> vij1 = *vj1;
+
+														t = cs * vij + sn * vij1;
+														*vj1 = -sn * vij + cs * vij1;
+														*vj = t;
+
+														vj += n; vj1 += n;
+													}
+												}
+											}
+										}
+
+										t = Accord.Math.Tools.Hypotenuse(f, g);
+										cs = f / t;
+										sn = g / t;
+										s[j] = t;
+										f = cs * e[j] + sn * s[j + 1];
+										s[j + 1] = -sn * e[j] + cs * s[j + 1];
+										g = sn * e[j + 1];
+										e[j + 1] = cs * e[j + 1];
+
+										if (wantu && (j < m - 1))
+										{
+											fixed (<#=T#>* ptr_uj = &u[0, j])
+											{
+												<#=T#>* uj = ptr_uj;
+												<#=T#>* uj1 = ptr_uj + 1;
+
+												for (int i = 0; i < m; i++)
+												{
+													/* t = cs * u[i, j] + sn * u[i, j + 1];
+													 u[i, j + 1] = -sn * u[i, j] + cs * u[i, j + 1];
+													 u[i, j] = t;*/
+
+													<#=T#> uij = *uj;
+													<#=T#> uij1 = *uj1;
+
+													t = cs * uij + sn * uij1;
+													*uj1 = -sn * uij + cs * uij1;
+													*uj = t;
+
+													uj += nu; uj1 += nu;
+												}
+											}
+										}
+
+									}
+
+									e[p - 2] = f;
+									iter = iter + 1;
+								}
+								break;
+
+							// Convergence.
+							case 4:
+								{
+									// Make the singular values positive.
+									if (s[k] <= 0)
+									{
+										s[k] = (s[k] < 0 ? -s[k] : 0);
+										if (wantv)
+										{
+											for (int i = 0; i <= pp; i++)
+												v[i, k] = -v[i, k];
+										}
+									}
+
+									// Order the singular values.
+									while (k < pp)
+									{
+										if (s[k] >= s[k + 1])
+											break;
+
+										<#=T#> t = s[k];
+										s[k] = s[k + 1];
+										s[k + 1] = t;
+
+										int ti = si[k];
+										si[k] = si[k + 1];
+										si[k + 1] = ti;
+
+										if (wantv && (k < n - 1))
+										{
+											for (int i = 0; i < n; i++)
+											{
+												t = v[i, k + 1];
+												v[i, k + 1] = v[i, k];
+												v[i, k] = t;
+											}
+										}
+
+										if (wantu && (k < m - 1))
+										{
+											for (int i = 0; i < m; i++)
+											{
+												t = u[i, k + 1];
+												u[i, k + 1] = u[i, k];
+												u[i, k] = t;
+											}
+										}
+
+										k++;
+									}
+
+									iter = 0;
+									p--;
+								}
+								break;
+						}
+					}
+				}
+			}
 
             // If we are violating JAMA's assumption about 
             // the input dimension, we need to swap u and v.

--- a/Sources/Accord.Math/Decompositions/SingularValueDecompositionF.cs
+++ b/Sources/Accord.Math/Decompositions/SingularValueDecompositionF.cs
@@ -342,7 +342,7 @@ namespace Accord.Math.Decompositions
         ///   <paramref name="value"/> will be destroyed in the process, resulting in less
         ///   memory comsumption.</param>
         /// 
-        public unsafe SingularValueDecompositionF(Single[,] value,
+        public SingularValueDecompositionF(Single[,] value,
            bool computeLeftSingularVectors, bool computeRightSingularVectors, bool autoTranspose, bool inPlace)
         {
             if (value == null)
@@ -405,546 +405,549 @@ namespace Accord.Math.Decompositions
             bool wantu = computeLeftSingularVectors;
             bool wantv = computeRightSingularVectors;
 
-            fixed (Single* U = u)
-            fixed (Single* V = v)
-            fixed (Single* A = a)
+            unsafe
             {
-
-                // Will store ordered sequence of indices after sorting.
-                si = new int[ni]; for (int i = 0; i < ni; i++) si[i] = i;
-
-
-                // Reduce A to bidiagonal form, storing the diagonal elements in s and the super-diagonal elements in e.
-                int nct = System.Math.Min(m - 1, n);
-                int nrt = System.Math.Max(0, System.Math.Min(n - 2, m));
-				int mrc = System.Math.Max(nct, nrt);
-
-                for (int k = 0; k < mrc; k++)
+                fixed (Single* U = u)
+                fixed (Single* V = v)
+                fixed (Single* A = a)
                 {
-                    if (k < nct)
+
+                    // Will store ordered sequence of indices after sorting.
+                    si = new int[ni]; for (int i = 0; i < ni; i++) si[i] = i;
+
+
+                    // Reduce A to bidiagonal form, storing the diagonal elements in s and the super-diagonal elements in e.
+                    int nct = System.Math.Min(m - 1, n);
+                    int nrt = System.Math.Max(0, System.Math.Min(n - 2, m));
+				    int mrc = System.Math.Max(nct, nrt);
+
+                    for (int k = 0; k < mrc; k++)
                     {
-                        // Compute the transformation for the k-th column and place the k-th diagonal in s[k].
-                        // Compute 2-norm of k-th column without under/overflow.
-                        s[k] = 0;
-                        for (int i = k; i < m; i++)
-                            s[k] = Accord.Math.Tools.Hypotenuse(s[k], a[i, k]);
-
-                        if (s[k] != 0)
+                        if (k < nct)
                         {
-                            if (a[k, k] < 0)
-                                s[k] = -s[k];
-
+                            // Compute the transformation for the k-th column and place the k-th diagonal in s[k].
+                            // Compute 2-norm of k-th column without under/overflow.
+                            s[k] = 0;
                             for (int i = k; i < m; i++)
-                                a[i, k] /= s[k];
+                                s[k] = Accord.Math.Tools.Hypotenuse(s[k], a[i, k]);
 
-                            a[k, k] += 1;
-                        }
-
-                        s[k] = -s[k];
-                    }
-
-                    for (int j = k + 1; j < n; j++)
-                    {
-                        Single* ptr_ak = A + k * n + k; // A[k,k]
-                        Single* ptr_aj = A + k * n + j; // A[k,j]
-
-                        if ((k < nct) & (s[k] != 0))
-                        {
-                            // Apply the transformation.
-                            Single t = 0;
-                            Single* ak = ptr_ak;
-                            Single* aj = ptr_aj;
-
-                            for (int i = k; i < m; i++)
+                            if (s[k] != 0)
                             {
-                                t += (*ak) * (*aj);
-                                ak += n; aj += n;
+                                if (a[k, k] < 0)
+                                    s[k] = -s[k];
+
+                                for (int i = k; i < m; i++)
+                                    a[i, k] /= s[k];
+
+                                a[k, k] += 1;
                             }
 
-                            t = -t / *ptr_ak;
-                            ak = ptr_ak;
-                            aj = ptr_aj;
-
-                            for (int i = k; i < m; i++)
-                            {
-                                *aj += t * (*ak);
-                                ak += n; aj += n;
-                            }
+                            s[k] = -s[k];
                         }
 
-                        // Place the k-th row of A into e for the subsequent calculation of the row transformation.
-                        e[j] = *ptr_aj;
-                    }
-
-
-                    if (wantu & (k < nct))
-                    {
-                        // Place the transformation in U for subsequent back
-                        // multiplication.
-                        for (int i = k; i < m; i++)
-                            u[i, k] = a[i, k];
-                    }
-
-                    if (k < nrt)
-                    {
-                        // Compute the k-th row transformation and place the k-th super-diagonal in e[k].
-                        // Compute 2-norm without under/overflow.
-                        e[k] = 0;
-                        for (int i = k + 1; i < n; i++)
-                            e[k] = Accord.Math.Tools.Hypotenuse(e[k], e[i]);
-
-                        if (e[k] != 0)
+                        for (int j = k + 1; j < n; j++)
                         {
-                            if (e[k + 1] < 0)
-                                e[k] = -e[k];
+                            Single* ptr_ak = A + k * n + k; // A[k,k]
+                            Single* ptr_aj = A + k * n + j; // A[k,j]
 
-                            for (int i = k + 1; i < n; i++)
-                                e[i] /= e[k];
-
-                            e[k + 1] += 1;
-                        }
-
-                        e[k] = -e[k];
-                        if ((k + 1 < m) & (e[k] != 0))
-                        {
-                            // Apply the transformation.
-                            for (int i = k + 1; i < m; i++)
-                                work[i] = 0;
-
-                            int k1 = k + 1;
-                            for (int i = k1; i < m; i++)
+                            if ((k < nct) & (s[k] != 0))
                             {
-                                Single* ai = A + (i * n) + k1;
-                                for (int j = k1; j < n; j++, ai++)
-                                    work[i] += e[j] * (*ai);
-                            }
-
-                            for (int j = k1; j < n; j++)
-                            {
-                                Single t = -e[j] / e[k1];
-                                Single* aj = A + (k1 * n) + j;
-                                for (int i = k1; i < m; i++, aj += n)
-                                    *aj += t * work[i];
-                            }
-                        }
-
-                        if (wantv)
-                        {
-                            // Place the transformation in V for subsequent back multiplication.
-                            for (int i = k + 1; i < n; i++)
-                                v[i, k] = e[i];
-                        }
-                    }
-                }
-
-                // Set up the final bidiagonal matrix or order p.
-                int p = System.Math.Min(n, m + 1);
-                if (nct < n) s[nct] = a[nct, nct];
-                if (m < p) s[p - 1] = 0;
-                if (nrt + 1 < p) e[nrt] = a[nrt, p - 1];
-                e[p - 1] = 0;
-
-                // If required, generate U.
-                if (wantu)
-                {
-                    for (int j = nct; j < nu; j++)
-                    {
-                        for (int i = 0; i < m; i++)
-                            u[i, j] = 0;
-                        u[j, j] = 1;
-                    }
-
-                    for (int k = nct - 1; k >= 0; k--)
-                    {
-                        if (s[k] != 0)
-                        {
-                            Single* ptr_uk = U + k * nu + k; // u[k,k]
-
-                            Single* uk, uj;
-                            for (int j = k + 1; j < nu; j++)
-                            {
-                                Single* ptr_uj = U + k * nu + j; // u[k,j]
-
+                                // Apply the transformation.
                                 Single t = 0;
-                                uk = ptr_uk;
-                                uj = ptr_uj;
+                                Single* ak = ptr_ak;
+                                Single* aj = ptr_aj;
 
                                 for (int i = k; i < m; i++)
                                 {
-                                    t += *uk * *uj;
-                                    uk += nu; uj += nu;
+                                    t += (*ak) * (*aj);
+                                    ak += n; aj += n;
                                 }
 
-                                t = -t / *ptr_uk;
+                                t = -t / *ptr_ak;
+                                ak = ptr_ak;
+                                aj = ptr_aj;
 
-                                uk = ptr_uk; uj = ptr_uj;
                                 for (int i = k; i < m; i++)
                                 {
-                                    *uj += t * (*uk);
-                                    uk += nu; uj += nu;
+                                    *aj += t * (*ak);
+                                    ak += n; aj += n;
                                 }
                             }
 
-                            uk = ptr_uk;
-                            for (int i = k; i < m; i++)
-                            {
-                                *uk = -(*uk);
-                                uk += nu;
-                            }
-
-                            u[k, k] = 1 + u[k, k];
-                            for (int i = 0; i < k - 1; i++)
-                                u[i, k] = 0;
+                            // Place the k-th row of A into e for the subsequent calculation of the row transformation.
+                            e[j] = *ptr_aj;
                         }
-                        else
+
+
+                        if (wantu & (k < nct))
+                        {
+                            // Place the transformation in U for subsequent back
+                            // multiplication.
+                            for (int i = k; i < m; i++)
+                                u[i, k] = a[i, k];
+                        }
+
+                        if (k < nrt)
+                        {
+                            // Compute the k-th row transformation and place the k-th super-diagonal in e[k].
+                            // Compute 2-norm without under/overflow.
+                            e[k] = 0;
+                            for (int i = k + 1; i < n; i++)
+                                e[k] = Accord.Math.Tools.Hypotenuse(e[k], e[i]);
+
+                            if (e[k] != 0)
+                            {
+                                if (e[k + 1] < 0)
+                                    e[k] = -e[k];
+
+                                for (int i = k + 1; i < n; i++)
+                                    e[i] /= e[k];
+
+                                e[k + 1] += 1;
+                            }
+
+                            e[k] = -e[k];
+                            if ((k + 1 < m) & (e[k] != 0))
+                            {
+                                // Apply the transformation.
+                                for (int i = k + 1; i < m; i++)
+                                    work[i] = 0;
+
+                                int k1 = k + 1;
+                                for (int i = k1; i < m; i++)
+                                {
+                                    Single* ai = A + (i * n) + k1;
+                                    for (int j = k1; j < n; j++, ai++)
+                                        work[i] += e[j] * (*ai);
+                                }
+
+                                for (int j = k1; j < n; j++)
+                                {
+                                    Single t = -e[j] / e[k1];
+                                    Single* aj = A + (k1 * n) + j;
+                                    for (int i = k1; i < m; i++, aj += n)
+                                        *aj += t * work[i];
+                                }
+                            }
+
+                            if (wantv)
+                            {
+                                // Place the transformation in V for subsequent back multiplication.
+                                for (int i = k + 1; i < n; i++)
+                                    v[i, k] = e[i];
+                            }
+                        }
+                    }
+
+                    // Set up the final bidiagonal matrix or order p.
+                    int p = System.Math.Min(n, m + 1);
+                    if (nct < n) s[nct] = a[nct, nct];
+                    if (m < p) s[p - 1] = 0;
+                    if (nrt + 1 < p) e[nrt] = a[nrt, p - 1];
+                    e[p - 1] = 0;
+
+                    // If required, generate U.
+                    if (wantu)
+                    {
+                        for (int j = nct; j < nu; j++)
                         {
                             for (int i = 0; i < m; i++)
-                                u[i, k] = 0;
-                            u[k, k] = 1;
+                                u[i, j] = 0;
+                            u[j, j] = 1;
+                        }
+
+                        for (int k = nct - 1; k >= 0; k--)
+                        {
+                            if (s[k] != 0)
+                            {
+                                Single* ptr_uk = U + k * nu + k; // u[k,k]
+
+                                Single* uk, uj;
+                                for (int j = k + 1; j < nu; j++)
+                                {
+                                    Single* ptr_uj = U + k * nu + j; // u[k,j]
+
+                                    Single t = 0;
+                                    uk = ptr_uk;
+                                    uj = ptr_uj;
+
+                                    for (int i = k; i < m; i++)
+                                    {
+                                        t += *uk * *uj;
+                                        uk += nu; uj += nu;
+                                    }
+
+                                    t = -t / *ptr_uk;
+
+                                    uk = ptr_uk; uj = ptr_uj;
+                                    for (int i = k; i < m; i++)
+                                    {
+                                        *uj += t * (*uk);
+                                        uk += nu; uj += nu;
+                                    }
+                                }
+
+                                uk = ptr_uk;
+                                for (int i = k; i < m; i++)
+                                {
+                                    *uk = -(*uk);
+                                    uk += nu;
+                                }
+
+                                u[k, k] = 1 + u[k, k];
+                                for (int i = 0; i < k - 1; i++)
+                                    u[i, k] = 0;
+                            }
+                            else
+                            {
+                                for (int i = 0; i < m; i++)
+                                    u[i, k] = 0;
+                                u[k, k] = 1;
+                            }
                         }
                     }
-                }
 
-                // If required, generate V.
-                if (wantv)
-                {
-                    for (int k = n - 1; k >= 0; k--)
+                    // If required, generate V.
+                    if (wantv)
                     {
-                        if ((k < nrt) & (e[k] != 0))
+                        for (int k = n - 1; k >= 0; k--)
                         {
-                            // TODO: The following is a pseudo correction to make SVD
-                            //  work on matrices with n > m (less rows than columns).
-
-                            // For the proper correction, compute the decomposition of the
-                            //  transpose of A and swap the left and right eigenvectors
-
-                            // Original line:
-                            //   for (int j = k + 1; j < nu; j++)
-                            // Pseudo correction:
-                            //   for (int j = k + 1; j < n; j++)
-
-                            for (int j = k + 1; j < n; j++) // pseudo-correction
+                            if ((k < nrt) & (e[k] != 0))
                             {
-                                Single* ptr_vk = V + (k + 1) * n + k; // v[k + 1, k]
-                                Single* ptr_vj = V + (k + 1) * n + j; // v[k + 1, j]
+                                // TODO: The following is a pseudo correction to make SVD
+                                //  work on matrices with n > m (less rows than columns).
 
-                                Single t = 0;
-                                Single* vk = ptr_vk;
-                                Single* vj = ptr_vj;
+                                // For the proper correction, compute the decomposition of the
+                                //  transpose of A and swap the left and right eigenvectors
 
-                                for (int i = k + 1; i < n; i++)
+                                // Original line:
+                                //   for (int j = k + 1; j < nu; j++)
+                                // Pseudo correction:
+                                //   for (int j = k + 1; j < n; j++)
+
+                                for (int j = k + 1; j < n; j++) // pseudo-correction
                                 {
-                                    t += *vk * *vj;
-                                    vk += n; vj += n;
-                                }
+                                    Single* ptr_vk = V + (k + 1) * n + k; // v[k + 1, k]
+                                    Single* ptr_vj = V + (k + 1) * n + j; // v[k + 1, j]
 
-                                t = -t / *ptr_vk;
+                                    Single t = 0;
+                                    Single* vk = ptr_vk;
+                                    Single* vj = ptr_vj;
 
-                                vk = ptr_vk; vj = ptr_vj;
-                                for (int i = k + 1; i < n; i++)
-                                {
-                                    *vj += t * (*vk);
-                                    vk += n; vj += n;
+                                    for (int i = k + 1; i < n; i++)
+                                    {
+                                        t += *vk * *vj;
+                                        vk += n; vj += n;
+                                    }
+
+                                    t = -t / *ptr_vk;
+
+                                    vk = ptr_vk; vj = ptr_vj;
+                                    for (int i = k + 1; i < n; i++)
+                                    {
+                                        *vj += t * (*vk);
+                                        vk += n; vj += n;
+                                    }
                                 }
+                            }
+
+                            for (int i = 0; i < n; i++)
+                                v[i, k] = 0;
+                            v[k, k] = 1;
+                        }
+                    }
+
+                    // Main iteration loop for the singular values.
+                    int pp = p - 1;
+                    int iter = 0;
+                    while (p > 0)
+                    {
+                        int k, kase;
+
+                        // Here is where a test for too many iterations would go.
+
+                        // This section of the program inspects for
+                        // negligible elements in the s and e arrays.  On
+                        // completion the variables kase and k are set as follows.
+
+                        // kase = 1     if s(p) and e[k-1] are negligible and k<p
+                        // kase = 2     if s(k) is negligible and k<p
+                        // kase = 3     if e[k-1] is negligible, k<p, and
+                        //              s(k), ..., s(p) are not negligible (qr step).
+                        // kase = 4     if e(p-1) is negligible (convergence).
+
+                        for (k = p - 2; k >= -1; k--)
+                        {
+                            if (k == -1)
+                                break;
+
+                            var alpha = tiny + eps * (System.Math.Abs(s[k]) + System.Math.Abs(s[k + 1]));
+
+                            if (System.Math.Abs(e[k]) <= alpha || Single.IsNaN(e[k]))
+                            {
+                                e[k] = 0;
+                                break;
                             }
                         }
 
-                        for (int i = 0; i < n; i++)
-                            v[i, k] = 0;
-                        v[k, k] = 1;
-                    }
-                }
-
-                // Main iteration loop for the singular values.
-                int pp = p - 1;
-                int iter = 0;
-                while (p > 0)
-                {
-                    int k, kase;
-
-                    // Here is where a test for too many iterations would go.
-
-                    // This section of the program inspects for
-                    // negligible elements in the s and e arrays.  On
-                    // completion the variables kase and k are set as follows.
-
-                    // kase = 1     if s(p) and e[k-1] are negligible and k<p
-                    // kase = 2     if s(k) is negligible and k<p
-                    // kase = 3     if e[k-1] is negligible, k<p, and
-                    //              s(k), ..., s(p) are not negligible (qr step).
-                    // kase = 4     if e(p-1) is negligible (convergence).
-
-                    for (k = p - 2; k >= -1; k--)
-                    {
-                        if (k == -1)
-                            break;
-
-                        var alpha = tiny + eps * (System.Math.Abs(s[k]) + System.Math.Abs(s[k + 1]));
-
-                        if (System.Math.Abs(e[k]) <= alpha || Single.IsNaN(e[k]))
+                        if (k == p - 2)
                         {
-                            e[k] = 0;
-                            break;
+                            kase = 4;
                         }
-                    }
-
-                    if (k == p - 2)
-                    {
-                        kase = 4;
-                    }
-                    else
-                    {
-                        int ks;
-                        for (ks = p - 1; ks >= k; ks--)
-                        {
-                            if (ks == k)
-                                break;
-
-                            Single t = (ks != p ? System.Math.Abs(e[ks]) : 0) +
-                                       (ks != k + 1 ? System.Math.Abs(e[ks - 1]) : 0);
-                            if (System.Math.Abs(s[ks]) <= tiny + eps * t)
-                            {
-                                s[ks] = 0;
-                                break;
-                            }
-                        }
-
-                        if (ks == k)
-                            kase = 3;
-                        else if (ks == p - 1)
-                            kase = 1;
                         else
                         {
-                            kase = 2;
-                            k = ks;
+                            int ks;
+                            for (ks = p - 1; ks >= k; ks--)
+                            {
+                                if (ks == k)
+                                    break;
+
+                                Single t = (ks != p ? System.Math.Abs(e[ks]) : 0) +
+                                           (ks != k + 1 ? System.Math.Abs(e[ks - 1]) : 0);
+                                if (System.Math.Abs(s[ks]) <= tiny + eps * t)
+                                {
+                                    s[ks] = 0;
+                                    break;
+                                }
+                            }
+
+                            if (ks == k)
+                                kase = 3;
+                            else if (ks == p - 1)
+                                kase = 1;
+                            else
+                            {
+                                kase = 2;
+                                k = ks;
+                            }
                         }
-                    }
 
-                    k++;
+                        k++;
 
-                    // Perform the task indicated by kase.
-                    switch (kase)
-                    {
-                        // Deflate negligible s(p).
-                        case 1:
-                            {
-                                Single f = e[p - 2];
-                                e[p - 2] = 0;
-                                for (int j = p - 2; j >= k; j--)
+                        // Perform the task indicated by kase.
+                        switch (kase)
+                        {
+                            // Deflate negligible s(p).
+                            case 1:
                                 {
-                                    Single t = Accord.Math.Tools.Hypotenuse(s[j], f);
-                                    Single cs = s[j] / t;
-                                    Single sn = f / t;
-                                    s[j] = t;
-                                    if (j != k)
+                                    Single f = e[p - 2];
+                                    e[p - 2] = 0;
+                                    for (int j = p - 2; j >= k; j--)
                                     {
-                                        f = -sn * e[j - 1];
-                                        e[j - 1] = cs * e[j - 1];
-                                    }
-
-                                    if (wantv)
-                                    {
-                                        for (int i = 0; i < n; i++)
+                                        Single t = Accord.Math.Tools.Hypotenuse(s[j], f);
+                                        Single cs = s[j] / t;
+                                        Single sn = f / t;
+                                        s[j] = t;
+                                        if (j != k)
                                         {
-                                            t = cs * v[i, j] + sn * v[i, p - 1];
-                                            v[i, p - 1] = -sn * v[i, j] + cs * v[i, p - 1];
-                                            v[i, j] = t;
+                                            f = -sn * e[j - 1];
+                                            e[j - 1] = cs * e[j - 1];
                                         }
-                                    }
-                                }
-                            }
-                            break;
 
-                        // Split at negligible s(k).
-                        case 2:
-                            {
-                                Single f = e[k - 1];
-                                e[k - 1] = 0;
-                                for (int j = k; j < p; j++)
-                                {
-                                    Single t = Accord.Math.Tools.Hypotenuse(s[j], f);
-                                    Single cs = s[j] / t;
-                                    Single sn = f / t;
-                                    s[j] = t;
-                                    f = -sn * e[j];
-                                    e[j] = cs * e[j];
-
-                                    if (wantu)
-                                    {
-                                        for (int i = 0; i < m; i++)
+                                        if (wantv)
                                         {
-                                            t = cs * u[i, j] + sn * u[i, k - 1];
-                                            u[i, k - 1] = -sn * u[i, j] + cs * u[i, k - 1];
-                                            u[i, j] = t;
-                                        }
-                                    }
-                                }
-                            }
-                            break;
-
-                        // Perform one qr step.
-                        case 3:
-                            {
-                                // Calculate the shift.
-                                Single scale = System.Math.Max(System.Math.Max(System.Math.Max(System.Math.Max(System.Math.Abs(s[p - 1]), System.Math.Abs(s[p - 2])), System.Math.Abs(e[p - 2])), System.Math.Abs(s[k])), System.Math.Abs(e[k]));
-                                Single sp = s[p - 1] / scale;
-                                Single spm1 = s[p - 2] / scale;
-                                Single epm1 = e[p - 2] / scale;
-                                Single sk = s[k] / scale;
-                                Single ek = e[k] / scale;
-                                Single b = ((spm1 + sp) * (spm1 - sp) + epm1 * epm1) / 2;
-                                Single c = (sp * epm1) * (sp * epm1);
-                                double shift = 0;
-
-                                if ((b != 0) | (c != 0))
-                                {
-                                    if (b < 0)
-                                        shift = -System.Math.Sqrt(b * b + c);
-                                    else
-                                        shift = System.Math.Sqrt(b * b + c);
-
-                                    shift = c / (b + shift);
-                                }
-
-                                Single f = (sk + sp) * (sk - sp) + (Single)shift;
-                                Single g = sk * ek;
-
-                                // Chase zeros.
-                                for (int j = k; j < p - 1; j++)
-                                {
-                                    Single t = Accord.Math.Tools.Hypotenuse(f, g);
-                                    Single cs = f / t;
-                                    Single sn = g / t;
-                                    if (j != k) e[j - 1] = t;
-                                    f = cs * s[j] + sn * e[j];
-                                    e[j] = cs * e[j] - sn * s[j];
-                                    g = sn * s[j + 1];
-                                    s[j + 1] = cs * s[j + 1];
-
-                                    if (wantv)
-                                    {
-                                        unsafe
-                                        {
-                                            fixed (Single* ptr_vj = &v[0, j])
+                                            for (int i = 0; i < n; i++)
                                             {
-                                                Single* vj = ptr_vj;
-                                                Single* vj1 = ptr_vj + 1;
+                                                t = cs * v[i, j] + sn * v[i, p - 1];
+                                                v[i, p - 1] = -sn * v[i, j] + cs * v[i, p - 1];
+                                                v[i, j] = t;
+                                            }
+                                        }
+                                    }
+                                }
+                                break;
 
-                                                for (int i = 0; i < n; i++)
+                            // Split at negligible s(k).
+                            case 2:
+                                {
+                                    Single f = e[k - 1];
+                                    e[k - 1] = 0;
+                                    for (int j = k; j < p; j++)
+                                    {
+                                        Single t = Accord.Math.Tools.Hypotenuse(s[j], f);
+                                        Single cs = s[j] / t;
+                                        Single sn = f / t;
+                                        s[j] = t;
+                                        f = -sn * e[j];
+                                        e[j] = cs * e[j];
+
+                                        if (wantu)
+                                        {
+                                            for (int i = 0; i < m; i++)
+                                            {
+                                                t = cs * u[i, j] + sn * u[i, k - 1];
+                                                u[i, k - 1] = -sn * u[i, j] + cs * u[i, k - 1];
+                                                u[i, j] = t;
+                                            }
+                                        }
+                                    }
+                                }
+                                break;
+
+                            // Perform one qr step.
+                            case 3:
+                                {
+                                    // Calculate the shift.
+                                    Single scale = System.Math.Max(System.Math.Max(System.Math.Max(System.Math.Max(System.Math.Abs(s[p - 1]), System.Math.Abs(s[p - 2])), System.Math.Abs(e[p - 2])), System.Math.Abs(s[k])), System.Math.Abs(e[k]));
+                                    Single sp = s[p - 1] / scale;
+                                    Single spm1 = s[p - 2] / scale;
+                                    Single epm1 = e[p - 2] / scale;
+                                    Single sk = s[k] / scale;
+                                    Single ek = e[k] / scale;
+                                    Single b = ((spm1 + sp) * (spm1 - sp) + epm1 * epm1) / 2;
+                                    Single c = (sp * epm1) * (sp * epm1);
+                                    double shift = 0;
+
+                                    if ((b != 0) | (c != 0))
+                                    {
+                                        if (b < 0)
+                                            shift = -System.Math.Sqrt(b * b + c);
+                                        else
+                                            shift = System.Math.Sqrt(b * b + c);
+
+                                        shift = c / (b + shift);
+                                    }
+
+                                    Single f = (sk + sp) * (sk - sp) + (Single)shift;
+                                    Single g = sk * ek;
+
+                                    // Chase zeros.
+                                    for (int j = k; j < p - 1; j++)
+                                    {
+                                        Single t = Accord.Math.Tools.Hypotenuse(f, g);
+                                        Single cs = f / t;
+                                        Single sn = g / t;
+                                        if (j != k) e[j - 1] = t;
+                                        f = cs * s[j] + sn * e[j];
+                                        e[j] = cs * e[j] - sn * s[j];
+                                        g = sn * s[j + 1];
+                                        s[j + 1] = cs * s[j + 1];
+
+                                        if (wantv)
+                                        {
+                                            unsafe
+                                            {
+                                                fixed (Single* ptr_vj = &v[0, j])
                                                 {
-                                                    /*t = cs * v[i, j] + sn * v[i, j + 1];
-                                                    v[i, j + 1] = -sn * v[i, j] + cs * v[i, j + 1];
-                                                    v[i, j] = t;*/
+                                                    Single* vj = ptr_vj;
+                                                    Single* vj1 = ptr_vj + 1;
 
-                                                    Single vij = *vj;
-                                                    Single vij1 = *vj1;
+                                                    for (int i = 0; i < n; i++)
+                                                    {
+                                                        /*t = cs * v[i, j] + sn * v[i, j + 1];
+                                                        v[i, j + 1] = -sn * v[i, j] + cs * v[i, j + 1];
+                                                        v[i, j] = t;*/
 
-                                                    t = cs * vij + sn * vij1;
-                                                    *vj1 = -sn * vij + cs * vij1;
-                                                    *vj = t;
+                                                        Single vij = *vj;
+                                                        Single vij1 = *vj1;
 
-                                                    vj += n; vj1 += n;
+                                                        t = cs * vij + sn * vij1;
+                                                        *vj1 = -sn * vij + cs * vij1;
+                                                        *vj = t;
+
+                                                        vj += n; vj1 += n;
+                                                    }
                                                 }
                                             }
                                         }
-                                    }
 
-                                    t = Accord.Math.Tools.Hypotenuse(f, g);
-                                    cs = f / t;
-                                    sn = g / t;
-                                    s[j] = t;
-                                    f = cs * e[j] + sn * s[j + 1];
-                                    s[j + 1] = -sn * e[j] + cs * s[j + 1];
-                                    g = sn * e[j + 1];
-                                    e[j + 1] = cs * e[j + 1];
+                                        t = Accord.Math.Tools.Hypotenuse(f, g);
+                                        cs = f / t;
+                                        sn = g / t;
+                                        s[j] = t;
+                                        f = cs * e[j] + sn * s[j + 1];
+                                        s[j + 1] = -sn * e[j] + cs * s[j + 1];
+                                        g = sn * e[j + 1];
+                                        e[j + 1] = cs * e[j + 1];
 
-                                    if (wantu && (j < m - 1))
-                                    {
-                                        fixed (Single* ptr_uj = &u[0, j])
+                                        if (wantu && (j < m - 1))
                                         {
-                                            Single* uj = ptr_uj;
-                                            Single* uj1 = ptr_uj + 1;
-
-                                            for (int i = 0; i < m; i++)
+                                            fixed (Single* ptr_uj = &u[0, j])
                                             {
-                                                /* t = cs * u[i, j] + sn * u[i, j + 1];
-                                                 u[i, j + 1] = -sn * u[i, j] + cs * u[i, j + 1];
-                                                 u[i, j] = t;*/
+                                                Single* uj = ptr_uj;
+                                                Single* uj1 = ptr_uj + 1;
 
-                                                Single uij = *uj;
-                                                Single uij1 = *uj1;
+                                                for (int i = 0; i < m; i++)
+                                                {
+                                                    /* t = cs * u[i, j] + sn * u[i, j + 1];
+                                                     u[i, j + 1] = -sn * u[i, j] + cs * u[i, j + 1];
+                                                     u[i, j] = t;*/
 
-                                                t = cs * uij + sn * uij1;
-                                                *uj1 = -sn * uij + cs * uij1;
-                                                *uj = t;
+                                                    Single uij = *uj;
+                                                    Single uij1 = *uj1;
 
-                                                uj += nu; uj1 += nu;
+                                                    t = cs * uij + sn * uij1;
+                                                    *uj1 = -sn * uij + cs * uij1;
+                                                    *uj = t;
+
+                                                    uj += nu; uj1 += nu;
+                                                }
                                             }
                                         }
+
                                     }
 
+                                    e[p - 2] = f;
+                                    iter = iter + 1;
                                 }
+                                break;
 
-                                e[p - 2] = f;
-                                iter = iter + 1;
-                            }
-                            break;
-
-                        // Convergence.
-                        case 4:
-                            {
-                                // Make the singular values positive.
-                                if (s[k] <= 0)
+                            // Convergence.
+                            case 4:
                                 {
-                                    s[k] = (s[k] < 0 ? -s[k] : 0);
-                                    if (wantv)
+                                    // Make the singular values positive.
+                                    if (s[k] <= 0)
                                     {
-                                        for (int i = 0; i <= pp; i++)
-                                            v[i, k] = -v[i, k];
-                                    }
-                                }
-
-                                // Order the singular values.
-                                while (k < pp)
-                                {
-                                    if (s[k] >= s[k + 1])
-                                        break;
-
-                                    Single t = s[k];
-                                    s[k] = s[k + 1];
-                                    s[k + 1] = t;
-
-                                    int ti = si[k];
-                                    si[k] = si[k + 1];
-                                    si[k + 1] = ti;
-
-                                    if (wantv && (k < n - 1))
-                                    {
-                                        for (int i = 0; i < n; i++)
+                                        s[k] = (s[k] < 0 ? -s[k] : 0);
+                                        if (wantv)
                                         {
-                                            t = v[i, k + 1];
-                                            v[i, k + 1] = v[i, k];
-                                            v[i, k] = t;
+                                            for (int i = 0; i <= pp; i++)
+                                                v[i, k] = -v[i, k];
                                         }
                                     }
 
-                                    if (wantu && (k < m - 1))
+                                    // Order the singular values.
+                                    while (k < pp)
                                     {
-                                        for (int i = 0; i < m; i++)
+                                        if (s[k] >= s[k + 1])
+                                            break;
+
+                                        Single t = s[k];
+                                        s[k] = s[k + 1];
+                                        s[k + 1] = t;
+
+                                        int ti = si[k];
+                                        si[k] = si[k + 1];
+                                        si[k + 1] = ti;
+
+                                        if (wantv && (k < n - 1))
                                         {
-                                            t = u[i, k + 1];
-                                            u[i, k + 1] = u[i, k];
-                                            u[i, k] = t;
+                                            for (int i = 0; i < n; i++)
+                                            {
+                                                t = v[i, k + 1];
+                                                v[i, k + 1] = v[i, k];
+                                                v[i, k] = t;
+                                            }
                                         }
+
+                                        if (wantu && (k < m - 1))
+                                        {
+                                            for (int i = 0; i < m; i++)
+                                            {
+                                                t = u[i, k + 1];
+                                                u[i, k + 1] = u[i, k];
+                                                u[i, k] = t;
+                                            }
+                                        }
+
+                                        k++;
                                     }
 
-                                    k++;
+                                    iter = 0;
+                                    p--;
                                 }
-
-                                iter = 0;
-                                p--;
-                            }
-                            break;
+                                break;
+                        }
                     }
                 }
             }

--- a/Sources/Accord.Math/Matrix/Matrix.Algebra.cs
+++ b/Sources/Accord.Math/Matrix/Matrix.Algebra.cs
@@ -349,7 +349,7 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A*B</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         /// 
-        public static unsafe void Multiply(this double[,] a, double[,] b, double[,] result)
+        public static void Multiply(this double[,] a, double[,] b, double[,] result)
         {
             // TODO: enable argument checking
             // if (a.GetLength(1) != b.GetLength(0))
@@ -359,22 +359,24 @@ namespace Accord.Math
             int m = result.GetLength(0); //a.GetLength(0);
             int p = result.GetLength(1); //b.GetLength(1);
 
-
-            fixed (double* ptrA = a)
+            unsafe
             {
-                double[] Bcolj = new double[n];
-                for (int j = 0; j < p; j++)
+                fixed (double* ptrA = a)
                 {
-                    for (int k = 0; k < Bcolj.Length; k++)
-                        Bcolj[k] = b[k, j];
-
-                    double* Arowi = ptrA;
-                    for (int i = 0; i < m; i++)
+                    double[] Bcolj = new double[n];
+                    for (int j = 0; j < p; j++)
                     {
-                        double s = 0;
                         for (int k = 0; k < Bcolj.Length; k++)
-                            s += *(Arowi++) * Bcolj[k];
-                        result[i, j] = s;
+                            Bcolj[k] = b[k, j];
+
+                        double* Arowi = ptrA;
+                        for (int i = 0; i < m; i++)
+                        {
+                            double s = 0;
+                            for (int k = 0; k < Bcolj.Length; k++)
+                                s += *(Arowi++) * Bcolj[k];
+                            result[i, j] = s;
+                        }
                     }
                 }
             }
@@ -430,7 +432,7 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A*B</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         /// 
-        public static unsafe void Multiply(this double[,] a, double[,] b, double[][] result)
+        public static void Multiply(this double[,] a, double[,] b, double[][] result)
         {
             // TODO: enable argument checking
             // if (a.GetLength(1) != b.GetLength(0))
@@ -440,22 +442,24 @@ namespace Accord.Math
             int m = a.GetLength(0);
             int p = b.GetLength(1);
 
-
-            fixed (double* ptrA = a)
+            unsafe
             {
-                double[] Bcolj = new double[n];
-                for (int j = 0; j < p; j++)
+                fixed (double* ptrA = a)
                 {
-                    for (int k = 0; k < Bcolj.Length; k++)
-                        Bcolj[k] = b[k, j];
-
-                    double* Arowi = ptrA;
-                    for (int i = 0; i < m; i++)
+                    double[] Bcolj = new double[n];
+                    for (int j = 0; j < p; j++)
                     {
-                        double s = 0;
                         for (int k = 0; k < Bcolj.Length; k++)
-                            s += *(Arowi++) * Bcolj[k];
-                        result[i][j] = s;
+                            Bcolj[k] = b[k, j];
+
+                        double* Arowi = ptrA;
+                        for (int i = 0; i < m; i++)
+                        {
+                            double s = 0;
+                            for (int k = 0; k < Bcolj.Length; k++)
+                                s += *(Arowi++) * Bcolj[k];
+                            result[i][j] = s;
+                        }
                     }
                 }
             }
@@ -551,27 +555,30 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A*B</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         /// 
-        public static unsafe void Multiply(this float[,] a, float[,] b, float[,] result)
+        public static void Multiply(this float[,] a, float[,] b, float[,] result)
         {
             int acols = a.GetLength(1);
             int arows = a.GetLength(0);
             int bcols = b.GetLength(1);
 
-            fixed (float* ptrA = a)
+            unsafe
             {
-                float[] Bcolj = new float[acols];
-                for (int j = 0; j < bcols; j++)
+                fixed (float* ptrA = a)
                 {
-                    for (int k = 0; k < acols; k++)
-                        Bcolj[k] = b[k, j];
-
-                    float* Arowi = ptrA;
-                    for (int i = 0; i < arows; i++)
+                    float[] Bcolj = new float[acols];
+                    for (int j = 0; j < bcols; j++)
                     {
-                        float s = 0;
                         for (int k = 0; k < acols; k++)
-                            s += *(Arowi++) * Bcolj[k];
-                        result[i, j] = s;
+                            Bcolj[k] = b[k, j];
+
+                        float* Arowi = ptrA;
+                        for (int i = 0; i < arows; i++)
+                        {
+                            float s = 0;
+                            for (int k = 0; k < acols; k++)
+                                s += *(Arowi++) * Bcolj[k];
+                            result[i, j] = s;
+                        }
                     }
                 }
             }
@@ -618,29 +625,32 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A*B'</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         ///    
-        public static unsafe void MultiplyByTranspose(this double[,] a, double[,] b, double[,] result)
+        public static void MultiplyByTranspose(this double[,] a, double[,] b, double[,] result)
         {
             int n = a.GetLength(1);
             int m = a.GetLength(0);
             int p = b.GetLength(0);
 
-            fixed (double* ptrA = a)
-            fixed (double* ptrB = b)
-            fixed (double* ptrR = result)
+            unsafe
             {
-                double* rc = ptrR;
-
-                for (int i = 0; i < m; i++)
+                fixed (double* ptrA = a)
+                fixed (double* ptrB = b)
+                fixed (double* ptrR = result)
                 {
-                    double* bColj = ptrB;
-                    for (int j = 0; j < p; j++)
-                    {
-                        double* aColi = ptrA + n * i;
+                    double* rc = ptrR;
 
-                        double s = 0;
-                        for (int k = 0; k < n; k++)
-                            s += *(aColi++) * *(bColj++);
-                        *(rc++) = s;
+                    for (int i = 0; i < m; i++)
+                    {
+                        double* bColj = ptrB;
+                        for (int j = 0; j < p; j++)
+                        {
+                            double* aColi = ptrA + n * i;
+
+                            double s = 0;
+                            for (int k = 0; k < n; k++)
+                                s += *(aColi++) * *(bColj++);
+                            *(rc++) = s;
+                        }
                     }
                 }
             }
@@ -656,29 +666,32 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A*B'</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         ///    
-        public static unsafe void MultiplyByTranspose(this float[,] a, float[,] b, float[,] result)
+        public static void MultiplyByTranspose(this float[,] a, float[,] b, float[,] result)
         {
             int n = a.GetLength(1);
             int m = a.GetLength(0);
             int p = b.GetLength(0);
 
-            fixed (float* ptrA = a)
-            fixed (float* ptrB = b)
-            fixed (float* ptrR = result)
+            unsafe
             {
-                float* rc = ptrR;
-
-                for (int i = 0; i < m; i++)
+                fixed (float* ptrA = a)
+                fixed (float* ptrB = b)
+                fixed (float* ptrR = result)
                 {
-                    float* bColj = ptrB;
-                    for (int j = 0; j < p; j++)
-                    {
-                        float* aColi = ptrA + n * i;
+                    float* rc = ptrR;
 
-                        float s = 0;
-                        for (int k = 0; k < n; k++)
-                            s += *(aColi++) * *(bColj++);
-                        *(rc++) = s;
+                    for (int i = 0; i < m; i++)
+                    {
+                        float* bColj = ptrB;
+                        for (int j = 0; j < p; j++)
+                        {
+                            float* aColi = ptrA + n * i;
+
+                            float s = 0;
+                            for (int k = 0; k < n; k++)
+                                s += *(aColi++) * *(bColj++);
+                            *(rc++) = s;
+                        }
                     }
                 }
             }
@@ -731,7 +744,7 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A'*B</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         /// 
-        public static unsafe void TransposeAndMultiply(this double[,] a, double[,] b, double[,] result)
+        public static void TransposeAndMultiply(this double[,] a, double[,] b, double[,] result)
         {
             if (a == null) throw new ArgumentNullException("a");
             if (b == null) throw new ArgumentNullException("b");
@@ -770,7 +783,7 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A'*B</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         /// 
-        public static unsafe void TransposeAndMultiply(this double[][] a, double[][] b, double[][] result)
+        public static void TransposeAndMultiply(this double[][] a, double[][] b, double[][] result)
         {
             if (a == null) throw new ArgumentNullException("a");
             if (b == null) throw new ArgumentNullException("b");
@@ -825,7 +838,7 @@ namespace Accord.Math
         /// <param name="result">The vector <c>r</c> to store the product <c>r = A'*b</c>
         ///   of the given matrix <c>A</c> and vector <c>b</c>.</param>
         /// 
-        public static unsafe void TransposeAndMultiply(this double[,] a, double[] b, double[] result)
+        public static void TransposeAndMultiply(this double[,] a, double[] b, double[] result)
         {
             if (a == null) throw new ArgumentNullException("a");
             if (b == null) throw new ArgumentNullException("b");
@@ -866,7 +879,7 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A*B</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         /// 
-        public static unsafe void TransposeAndMultiplyByDiagonal(this double[,] a, double[] b, double[,] result)
+        public static void TransposeAndMultiplyByDiagonal(this double[,] a, double[] b, double[,] result)
         {
             if (a.GetLength(0) != b.Length)
                 throw new ArgumentException("Matrix dimensions must match.");
@@ -939,7 +952,7 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A*B</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         /// 
-        public static unsafe void MultiplyByDiagonal(this double[,] a, double[] b, double[,] result)
+        public static void MultiplyByDiagonal(this double[,] a, double[] b, double[,] result)
         {
             if (a.GetLength(1) != b.Length)
                 throw new ArgumentException("Matrix dimensions must match.");
@@ -947,13 +960,16 @@ namespace Accord.Math
 
             int rows = a.GetLength(0);
 
-            fixed (double* ptrA = a, ptrR = result)
+            unsafe
             {
-                double* A = ptrA;
-                double* R = ptrR;
-                for (int i = 0; i < rows; i++)
-                    for (int j = 0; j < b.Length; j++)
-                        *R++ = *A++ * b[j];
+                fixed (double* ptrA = a, ptrR = result)
+                {
+                    double* A = ptrA;
+                    double* R = ptrR;
+                    for (int i = 0; i < rows; i++)
+                        for (int j = 0; j < b.Length; j++)
+                            *R++ = *A++ * b[j];
+                }
             }
         }
 
@@ -966,7 +982,7 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A*B</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         /// 
-        public static unsafe void MultiplyByDiagonal(this double[][] a, double[] b, double[][] result)
+        public static void MultiplyByDiagonal(this double[][] a, double[] b, double[][] result)
         {
             int rows = a.Length;
 
@@ -984,7 +1000,7 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A*B</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         /// 
-        public static unsafe void MultiplyByDiagonal(this float[][] a, float[] b, float[][] result)
+        public static void MultiplyByDiagonal(this float[][] a, float[] b, float[][] result)
         {
             int rows = a.Length;
 
@@ -1017,7 +1033,7 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A*B</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         /// 
-        public static unsafe void MultiplyByDiagonal(this float[,] a, float[] b, float[,] result)
+        public static void MultiplyByDiagonal(this float[,] a, float[] b, float[,] result)
         {
             if (a.GetLength(1) != b.Length)
                 throw new ArgumentException("Matrix dimensions must match.");
@@ -1025,13 +1041,16 @@ namespace Accord.Math
 
             int rows = a.GetLength(0);
 
-            fixed (float* ptrA = a, ptrR = result)
+            unsafe
             {
-                float* A = ptrA;
-                float* R = ptrR;
-                for (int i = 0; i < rows; i++)
-                    for (int j = 0; j < b.Length; j++)
-                        *R++ = *A++ * b[j];
+                fixed (float* ptrA = a, ptrR = result)
+                {
+                    float* A = ptrA;
+                    float* R = ptrR;
+                    for (int i = 0; i < rows; i++)
+                        for (int j = 0; j < b.Length; j++)
+                            *R++ = *A++ * b[j];
+                }
             }
         }
 
@@ -1059,7 +1078,7 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R = A*B</c>
         ///   of the given matrices <c>A</c> and <c>B</c>.</param>
         /// 
-        public static unsafe void DivideByDiagonal(this double[,] a, double[] b, double[,] result)
+        public static void DivideByDiagonal(this double[,] a, double[] b, double[,] result)
         {
             if (a.GetLength(1) != b.Length)
                 throw new ArgumentException("Matrix dimensions must match.");
@@ -1067,13 +1086,16 @@ namespace Accord.Math
 
             int rows = a.GetLength(0);
 
-            fixed (double* ptrA = a, ptrR = result)
+            unsafe
             {
-                double* A = ptrA;
-                double* R = ptrR;
-                for (int i = 0; i < rows; i++)
-                    for (int j = 0; j < b.Length; j++)
-                        *R++ = *A++ / b[j];
+                fixed (double* ptrA = a, ptrR = result)
+                {
+                    double* A = ptrA;
+                    double* R = ptrR;
+                    for (int i = 0; i < rows; i++)
+                        for (int j = 0; j < b.Length; j++)
+                            *R++ = *A++ / b[j];
+                }
             }
         }
 
@@ -1310,15 +1332,18 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R=A*x</c>
         ///   of the multiplication of the given matrix <c>A</c> and scalar <c>x</c>.</param>
         /// 
-        public unsafe static void Multiply(this double[,] matrix, double x, double[,] result)
+        public static void Multiply(this double[,] matrix, double x, double[,] result)
         {
             int length = matrix.Length;
 
-            fixed (double* ptrA = matrix, ptrR = result)
+            unsafe
             {
-                double* pa = ptrA, pr = ptrR;
-                for (int i = 0; i < length; i++, pa++, pr++)
-                    *pr = *pa * x;
+                fixed (double* ptrA = matrix, ptrR = result)
+                {
+                    double* pa = ptrA, pr = ptrR;
+                    for (int i = 0; i < length; i++, pa++, pr++)
+                        *pr = *pa * x;
+                }
             }
         }
 
@@ -1331,15 +1356,18 @@ namespace Accord.Math
         /// <param name="result">The matrix <c>R</c> to store the product <c>R=A*x</c>
         ///   of the multiplication of the given matrix <c>A</c> and scalar <c>x</c>.</param>
         /// 
-        public unsafe static void Multiply(this float[,] matrix, float x, float[,] result)
+        public static void Multiply(this float[,] matrix, float x, float[,] result)
         {
             int length = matrix.Length;
 
-            fixed (float* ptrA = matrix, ptrR = result)
+            unsafe
             {
-                float* pa = ptrA, pr = ptrR;
-                for (int i = 0; i < length; i++, pa++, pr++)
-                    *pr = *pa * x;
+                fixed (float* ptrA = matrix, ptrR = result)
+                {
+                    float* pa = ptrA, pr = ptrR;
+                    for (int i = 0; i < length; i++, pa++, pr++)
+                        *pr = *pa * x;
+                }
             }
         }
 
@@ -1912,7 +1940,7 @@ namespace Accord.Math
         /// 
         /// <returns>The Kronecker product of the two matrices.</returns>
         /// 
-        public unsafe static double[,] KroneckerProduct(this double[,] a, double[,] b)
+        public static double[,] KroneckerProduct(this double[,] a, double[,] b)
         {
             if (a == null) throw new ArgumentNullException("a");
             if (b == null) throw new ArgumentNullException("b");
@@ -1930,22 +1958,25 @@ namespace Accord.Math
 
             double[,] result = new double[crows, ccols];
 
-            fixed (double* ptrR = result, ptrA = a, ptrB = b)
+            unsafe
             {
-                double* A = ptrA, Ri = ptrR;
-
-                for (int i = 0; i < arows; Ri += block, i++)
+                fixed (double* ptrR = result, ptrA = a, ptrB = b)
                 {
-                    double* Rj = Ri;
+                    double* A = ptrA, Ri = ptrR;
 
-                    for (int j = 0; j < acols; j++, Rj += bcols, A++)
+                    for (int i = 0; i < arows; Ri += block, i++)
                     {
-                        double* R = Rj, B = ptrB;
+                        double* Rj = Ri;
 
-                        for (int k = 0; k < brows; k++, R += ccols)
+                        for (int j = 0; j < acols; j++, Rj += bcols, A++)
                         {
-                            for (int l = 0; l < bcols; l++, B++)
-                                *(R + l) = (*A) * (*B);
+                            double* R = Rj, B = ptrB;
+
+                            for (int k = 0; k < brows; k++, R += ccols)
+                            {
+                                for (int l = 0; l < bcols; l++, B++)
+                                    *(R + l) = (*A) * (*B);
+                            }
                         }
                     }
                 }
@@ -2019,7 +2050,7 @@ namespace Accord.Math
         /// 
         /// <returns>The sum of the given matrices.</returns>
         /// 
-        public unsafe static double[,] Add(this double[,] a, double[,] b)
+        public static double[,] Add(this double[,] a, double[,] b)
         {
             if (a.GetLength(0) != b.GetLength(0) || a.GetLength(1) != b.GetLength(1))
                 throw new ArgumentException("Matrix dimensions must match", "b");
@@ -2030,11 +2061,14 @@ namespace Accord.Math
 
             double[,] r = new double[rows, cols];
 
-            fixed (double* ptrA = a, ptrB = b, ptrR = r)
+            unsafe
             {
-                double* pa = ptrA, pb = ptrB, pr = ptrR;
-                for (int i = 0; i < length; i++, pa++, pb++, pr++)
-                    *pr = *pa + *pb;
+                fixed (double* ptrA = a, ptrB = b, ptrR = r)
+                {
+                    double* pa = ptrA, pb = ptrB, pr = ptrR;
+                    for (int i = 0; i < length; i++, pa++, pb++, pr++)
+                        *pr = *pa + *pb;
+                }
             }
 
             return r;
@@ -2340,7 +2374,7 @@ namespace Accord.Math
         /// 
         /// <returns>The subtraction of the given matrices.</returns>
         /// 
-        public unsafe static double[,] Subtract(this double[,] a, double[,] b, bool inPlace = false)
+        public static double[,] Subtract(this double[,] a, double[,] b, bool inPlace = false)
         {
             if (a == null) throw new ArgumentNullException("a");
             if (b == null) throw new ArgumentNullException("b");
@@ -2354,11 +2388,14 @@ namespace Accord.Math
 
             double[,] r = inPlace ? a : new double[rows, cols];
 
-            fixed (double* ptrA = a, ptrB = b, ptrR = r)
+            unsafe
             {
-                double* pa = ptrA, pb = ptrB, pr = ptrR;
-                for (int i = 0; i < length; i++, pa++, pb++, pr++)
-                    *pr = *pa - *pb;
+                fixed (double* ptrA = a, ptrB = b, ptrR = r)
+                {
+                    double* pa = ptrA, pb = ptrB, pr = ptrR;
+                    for (int i = 0; i < length; i++, pa++, pb++, pr++)
+                        *pr = *pa - *pb;
+                }
             }
             return r;
         }

--- a/Sources/Accord.Math/Matrix/Matrix.Common.cs
+++ b/Sources/Accord.Math/Matrix/Matrix.Common.cs
@@ -1146,23 +1146,26 @@ namespace Accord.Math
         ///   Gets the trace of a matrix product.
         /// </summary>
         /// 
-        public static unsafe double Trace(double[,] matrixA, double[,] matrixB)
+        public static double Trace(double[,] matrixA, double[,] matrixB)
         {
             if (matrixA.Length != matrixB.Length)
                 throw new DimensionMismatchException("matrixB", "Matrices must have the same length.");
 
             int length = matrixA.Length;
 
-            fixed (double* ptrA = matrixA)
-            fixed (double* ptrB = matrixB)
+            unsafe
             {
-                double* a = ptrA;
-                double* b = ptrB;
+                fixed (double* ptrA = matrixA)
+                fixed (double* ptrB = matrixB)
+                {
+                    double* a = ptrA;
+                    double* b = ptrB;
 
-                double trace = 0.0;
-                for (int i = 0; i < length; i++)
-                    trace += (*a++) * (*b++);
-                return trace;
+                    double trace = 0.0;
+                    for (int i = 0; i < length; i++)
+                        trace += (*a++) * (*b++);
+                    return trace;
+                }
             }
         }
 

--- a/Sources/Accord.Math/Matrix/Matrix.Conversions.cs
+++ b/Sources/Accord.Math/Matrix/Matrix.Conversions.cs
@@ -170,7 +170,7 @@ namespace Accord.Math
         ///   array.
         /// </summary>
         /// 
-        public unsafe static double[,] ToDouble(this float[,] matrix)
+        public static double[,] ToDouble(this float[,] matrix)
         {
             int rows = matrix.GetLength(0);
             int cols = matrix.GetLength(1);
@@ -178,14 +178,17 @@ namespace Accord.Math
 
             double[,] result = new double[rows, cols];
 
-            fixed (float* srcPtr = matrix)
-            fixed (double* dstPtr = result)
+            unsafe
             {
-                float* src = srcPtr;
-                double* dst = dstPtr;
+                fixed (float* srcPtr = matrix)
+                fixed (double* dstPtr = result)
+                {
+                    float* src = srcPtr;
+                    double* dst = dstPtr;
 
-                for (int i = 0; i < length; i++, src++, dst++)
-                    *dst = (double)*src;
+                    for (int i = 0; i < length; i++, src++, dst++)
+                        *dst = (double)*src;
+                }
             }
 
             return result;
@@ -196,7 +199,7 @@ namespace Accord.Math
         ///   precision floating point multidimensional array.
         /// </summary>
         /// 
-        public unsafe static double[,] ToDouble(this byte[,] matrix)
+        public static double[,] ToDouble(this byte[,] matrix)
         {
             int rows = matrix.GetLength(0);
             int cols = matrix.GetLength(1);
@@ -204,14 +207,17 @@ namespace Accord.Math
 
             double[,] result = new double[rows, cols];
 
-            fixed (byte* srcPtr = matrix)
-            fixed (double* dstPtr = result)
+            unsafe
             {
-                byte* src = srcPtr;
-                double* dst = dstPtr;
+                fixed (byte* srcPtr = matrix)
+                fixed (double* dstPtr = result)
+                {
+                    byte* src = srcPtr;
+                    double* dst = dstPtr;
 
-                for (int i = 0; i < length; i++, src++, dst++)
-                    *dst = (double)*src;
+                    for (int i = 0; i < length; i++, src++, dst++)
+                        *dst = (double)*src;
+                }
             }
 
             return result;
@@ -223,7 +229,7 @@ namespace Accord.Math
         ///   array.
         /// </summary>
         /// 
-        public unsafe static double[,] ToDouble(this int[,] matrix)
+        public static double[,] ToDouble(this int[,] matrix)
         {
             int rows = matrix.GetLength(0);
             int cols = matrix.GetLength(1);
@@ -231,14 +237,17 @@ namespace Accord.Math
 
             double[,] result = new double[rows, cols];
 
-            fixed (int* srcPtr = matrix)
-            fixed (double* dstPtr = result)
+            unsafe
             {
-                int* src = srcPtr;
-                double* dst = dstPtr;
+                fixed (int* srcPtr = matrix)
+                fixed (double* dstPtr = result)
+                {
+                    int* src = srcPtr;
+                    double* dst = dstPtr;
 
-                for (int i = 0; i < length; i++, src++, dst++)
-                    *dst = (double)*src;
+                    for (int i = 0; i < length; i++, src++, dst++)
+                        *dst = (double)*src;
+                }
             }
 
             return result;
@@ -250,7 +259,7 @@ namespace Accord.Math
         ///   array.
         /// </summary>
         /// 
-        public unsafe static float[,] ToSingle(this double[,] matrix)
+        public static float[,] ToSingle(this double[,] matrix)
         {
             int rows = matrix.GetLength(0);
             int cols = matrix.GetLength(1);
@@ -258,14 +267,17 @@ namespace Accord.Math
 
             float[,] result = new float[rows, cols];
 
-            fixed (double* srcPtr = matrix)
-            fixed (float* dstPtr = result)
+            unsafe
             {
-                double* src = srcPtr;
-                float* dst = dstPtr;
+                fixed (double* srcPtr = matrix)
+                fixed (float* dstPtr = result)
+                {
+                    double* src = srcPtr;
+                    float* dst = dstPtr;
 
-                for (int i = 0; i < length; i++, src++, dst++)
-                    *dst = (float)*src;
+                    for (int i = 0; i < length; i++, src++, dst++)
+                        *dst = (float)*src;
+                }
             }
 
             return result;
@@ -276,7 +288,7 @@ namespace Accord.Math
         /// </summary>
         /// <param name="matrix">The matrix to be truncated.</param>
         /// 
-        public unsafe static int[,] ToInt32(this double[,] matrix)
+        public static int[,] ToInt32(this double[,] matrix)
         {
             int rows = matrix.GetLength(0);
             int cols = matrix.GetLength(1);
@@ -284,14 +296,17 @@ namespace Accord.Math
 
             int[,] result = new int[rows, cols];
 
-            fixed (double* srcPtr = matrix)
-            fixed (int* dstPtr = result)
+            unsafe
             {
-                double* src = srcPtr;
-                int* dst = dstPtr;
+                fixed (double* srcPtr = matrix)
+                fixed (int* dstPtr = result)
+                {
+                    double* src = srcPtr;
+                    int* dst = dstPtr;
 
-                for (int i = 0; i < length; i++, src++, dst++)
-                    *dst = (int)*src;
+                    for (int i = 0; i < length; i++, src++, dst++)
+                        *dst = (int)*src;
+                }
             }
 
             return result;

--- a/Sources/Accord.Math/Tools.cs
+++ b/Sources/Accord.Math/Tools.cs
@@ -600,14 +600,17 @@ namespace Accord.Math
         ///   Fast inverse floating-point square root.
         /// </summary>
         /// 
-        public unsafe static float InvSqrt(float f)
+        public static float InvSqrt(float f)
         {
-            float xhalf = 0.5f * f;
-            Int32 i = *(Int32*)&f;
-            i = 0x5f375a86 - (i >> 1);
-            f = *(float*)&i;
-            f = f * (1.5f - xhalf * f * f);
-            return f;
+            unsafe
+            {
+                float xhalf = 0.5f * f;
+                Int32 i = *(Int32*)&f;
+                i = 0x5f375a86 - (i >> 1);
+                f = *(float*)&i;
+                f = f * (1.5f - xhalf * f * f);
+                return f;
+            }
         }
 
 

--- a/Sources/Accord.Video.Ximea/XimeaCamera.cs
+++ b/Sources/Accord.Video.Ximea/XimeaCamera.cs
@@ -392,7 +392,7 @@ namespace AForge.Video.Ximea
         /// <remarks><para>The method calls <see cref="GetImage(int)"/> method specifying 5000 as the timeout
         /// value.</para></remarks>
         ///
-        public unsafe Bitmap GetImage( )
+        public Bitmap GetImage( )
         {
             return GetImage( 5000 );
         }
@@ -408,7 +408,7 @@ namespace AForge.Video.Ximea
         /// <remarks><para>The method calls <see cref="GetImage(int,bool)"/> method specifying <see langword="true"/>
         /// the <b>makeCopy</b> parameter.</para></remarks>
         ///
-        public unsafe Bitmap GetImage( int timeout )
+        public Bitmap GetImage( int timeout )
         {
             return GetImage( timeout, true );
         }

--- a/Sources/Accord.Vision/AForge/Motion/BlobCountingObjectsProcessing.cs
+++ b/Sources/Accord.Vision/AForge/Motion/BlobCountingObjectsProcessing.cs
@@ -253,7 +253,7 @@ namespace AForge.Vision.Motion
         /// <exception cref="InvalidImagePropertiesException">Motion frame is not 8 bpp image, but it must be so.</exception>
         /// <exception cref="UnsupportedImageFormatException">Video frame must be 8 bpp grayscale image or 24/32 bpp color image.</exception>
         /// 
-        public unsafe void ProcessFrame( UnmanagedImage videoFrame, UnmanagedImage motionFrame )
+        public void ProcessFrame( UnmanagedImage videoFrame, UnmanagedImage motionFrame )
         {
             if ( motionFrame.PixelFormat != PixelFormat.Format8bppIndexed )
             {

--- a/Sources/Accord.Vision/AForge/Motion/MotionBorderHighlighting.cs
+++ b/Sources/Accord.Vision/AForge/Motion/MotionBorderHighlighting.cs
@@ -97,7 +97,7 @@ namespace AForge.Vision.Motion
         /// <exception cref="InvalidImagePropertiesException">Motion frame is not 8 bpp image, but it must be so.</exception>
         /// <exception cref="UnsupportedImageFormatException">Video frame must be 8 bpp grayscale image or 24/32 bpp color image.</exception>
         ///
-        public unsafe void ProcessFrame( UnmanagedImage videoFrame, UnmanagedImage motionFrame )
+        public void ProcessFrame( UnmanagedImage videoFrame, UnmanagedImage motionFrame )
         {
             if ( motionFrame.PixelFormat != PixelFormat.Format8bppIndexed )
             {
@@ -119,61 +119,64 @@ namespace AForge.Vision.Motion
             if ( ( motionFrame.Width != width ) || ( motionFrame.Height != height ) )
                 return;
 
-            byte* src    = (byte*) videoFrame.ImageData.ToPointer( );
-            byte* motion = (byte*) motionFrame.ImageData.ToPointer( );
-
-            int srcOffset    = videoFrame.Stride  - ( width - 2 ) * pixelSize;
-            int motionOffset = motionFrame.Stride - ( width - 2 );
-
-            src    += videoFrame.Stride + pixelSize;
-            motion += motionFrame.Stride + 1;
-
-            int widthM1  = width - 1;
-            int heightM1 = height - 1;
-
-            // use simple edge detector
-            if ( pixelSize == 1 )
+            unsafe
             {
-                // grayscale case
-                byte fillG = (byte) ( 0.2125 * highlightColor.R +
-                                      0.7154 * highlightColor.G +
-                                      0.0721 * highlightColor.B );
+                byte* src    = (byte*) videoFrame.ImageData.ToPointer( );
+                byte* motion = (byte*) motionFrame.ImageData.ToPointer( );
 
-                for ( int y = 1; y < heightM1; y++ )
+                int srcOffset    = videoFrame.Stride  - ( width - 2 ) * pixelSize;
+                int motionOffset = motionFrame.Stride - ( width - 2 );
+
+                src    += videoFrame.Stride + pixelSize;
+                motion += motionFrame.Stride + 1;
+
+                int widthM1  = width - 1;
+                int heightM1 = height - 1;
+
+                // use simple edge detector
+                if ( pixelSize == 1 )
                 {
-                    for ( int x = 1; x < widthM1; x++, motion++, src++ )
-                    {
-                        if ( 4 * *motion - motion[-width] - motion[width] - motion[1] - motion[-1] != 0 )
-                        {
-                            *src = fillG;
-                        }
-                    }
+                    // grayscale case
+                    byte fillG = (byte) ( 0.2125 * highlightColor.R +
+                                          0.7154 * highlightColor.G +
+                                          0.0721 * highlightColor.B );
 
-                    motion += motionOffset;
-                    src += srcOffset;
+                    for ( int y = 1; y < heightM1; y++ )
+                    {
+                        for ( int x = 1; x < widthM1; x++, motion++, src++ )
+                        {
+                            if ( 4 * *motion - motion[-width] - motion[width] - motion[1] - motion[-1] != 0 )
+                            {
+                                *src = fillG;
+                            }
+                        }
+
+                        motion += motionOffset;
+                        src += srcOffset;
+                    }
                 }
-            }
-            else
-            {
-                // color case
-                byte fillR = highlightColor.R;
-                byte fillG = highlightColor.G;
-                byte fillB = highlightColor.B;
-
-                for ( int y = 1; y < heightM1; y++ )
+                else
                 {
-                    for ( int x = 1; x < widthM1; x++, motion++, src += pixelSize )
-                    {
-                        if ( 4 * *motion - motion[-width] - motion[width] - motion[1] - motion[-1] != 0 )
-                        {
-                            src[RGB.R] = fillR;
-                            src[RGB.G] = fillG;
-                            src[RGB.B] = fillB;
-                        }
-                    }
+                    // color case
+                    byte fillR = highlightColor.R;
+                    byte fillG = highlightColor.G;
+                    byte fillB = highlightColor.B;
 
-                    motion += motionOffset;
-                    src += srcOffset;
+                    for ( int y = 1; y < heightM1; y++ )
+                    {
+                        for ( int x = 1; x < widthM1; x++, motion++, src += pixelSize )
+                        {
+                            if ( 4 * *motion - motion[-width] - motion[width] - motion[1] - motion[-1] != 0 )
+                            {
+                                src[RGB.R] = fillR;
+                                src[RGB.G] = fillG;
+                                src[RGB.B] = fillB;
+                            }
+                        }
+
+                        motion += motionOffset;
+                        src += srcOffset;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Dear César,

I have removed `unsafe` from the method signatures where the arguments and return values are not pointers, and instead placed the unsafe code inside `unsafe` code blocks. 

This should make the Accord.NET public API even more far-reaching.

I have successfully run the unit tests after this change.

From the diffs below you may get the impression that I have made larger changes, but it is just that I have indented the code inside the added `unsafe` blocks. The code itself is left unchanged.

There are a few public classes and methods that must keep the `unsafe` declaration, since they contain pointer fields (classes) and pointer arguments (methods).

In *Accord.Imaging*:

    PointedColorFloodFill class
    PointedMeanFloodFill class
    IntegralImage2 class
    UnsafeTools class

In *Accord.Core*:
    
    SystemTools.CopyUnmanagedMemory method
    SystemTools.SetUnamangedMemory method

In *Accord.Video.DirectShow*:
    
    Win32.memcpy method

I had code generation problems when I updated the *SingularValueDecomposition.tt* T4 template file. However, I believe that the update of the template file should be correct, and I have also manually edited the corresponding source code files to ensure a correct build.

I hope you find this pull request worthwhile to merge.

Best regards,
Anders

PS. I hope you don't mind me jumping ahead with this issue, I got a little carried away when I realized that there were parts of the code that could be easliy "safe"-ified. If you prefer that the method signatures are `unsafe` to more clearly signal that the method is using unsafe constructs internally, then this pull request is irrelevant. In that case, just reject this PR.