### PR TITLE
fixed missing loop variables.

### DIFF
--- a/Sources/Accord.Audio/Filters/EnvelopeFilter.cs
+++ b/Sources/Accord.Audio/Filters/EnvelopeFilter.cs
@@ -98,7 +98,7 @@ namespace Accord.Audio.Filters
                 for (int i = 0; i < channels; i++, src++, dst++)
                     *dst = System.Math.Abs(*src);
 
-                for (int i = channels; i < length; i++)
+                for (int i = channels; i < length; i++, src++, dst++)
                 {
                     float abs = System.Math.Abs(*src);
                     *dst = dst[-channels] + Alpha * (abs - dst[-channels]);


### PR DESCRIPTION
EnvelopeFilter was not working because the loop variables were not being incremented. 