### PR TITLE
In CompareTo(object), call CompareTo(KDTreeNodeDistance<T>)

### DIFF
--- a/Sources/Accord.MachineLearning/Structures/KDTreeNodeDistance.cs
+++ b/Sources/Accord.MachineLearning/Structures/KDTreeNodeDistance.cs
@@ -182,7 +182,7 @@ namespace Accord.MachineLearning.Structures
         /// 
         public int CompareTo(object obj)
         {
-            return distance.CompareTo((KDTreeNodeDistance<T>)obj);
+            return CompareTo((KDTreeNodeDistance<T>)obj);
         }
     }
 }


### PR DESCRIPTION
In the general `KDTreeNodeDistance<T>.CompareTo(object)` method, the following comparison with the field `distance` and the parameter `obj` is currently being made:

    return distance.CompareTo((KDTreeNodeDistance<T>)obj);

But since `distance` is a `double` this is effectively the same as calling:

    return distance.CompareTo((object)obj);

The correct call would instead be to dispatch the comparison to the specific `CompareTo` method defined in the same class:

    return CompareTo((KDTreeNodeDistance<T>)obj);

This pull request provides the aforementioned correction.