### PR TITLE
Use BitArray.Length instead of BitArray.Count

### DIFF
--- a/Sources/Accord.Math/Distances/Hamming.cs
+++ b/Sources/Accord.Math/Distances/Hamming.cs
@@ -152,13 +152,13 @@ namespace Accord.Math.Distances
         {
             BitArray bytes = x.Xor(y);
 
-            int numBytes = bytes.Count / 8;
-            if (x.Count % 8 != 0)
+            int numBytes = bytes.Length / 8;
+            if (x.Length % 8 != 0)
                 numBytes++;
 
             byte b = 0;
             double sum = 0;
-            for (int i = 0, j = 0; i < bytes.Count; i++, j++)
+            for (int i = 0, j = 0; i < bytes.Length; i++, j++)
             {
                 if (bytes[i])
                     b |= (byte)(1 << (8 - j));


### PR DESCRIPTION
In the `Hamming.Distance` method, the [`BitArray.Count`](https://msdn.microsoft.com/en-us/library/system.collections.bitarray.count.aspx) property getter has been used. This property is unfortunately .NET Framework specific and is **not** generally applicable to other C# based platforms like the *Universal Windows Platform*.

To facilitate building *Accord.Math* as a Portable Class Library (like in *Portable Accord* [here](https://github.com/cureos/accord)) it is therefore recommended that the `BitArray.Count` getter is replaced with the equivalent and portable [`BitArray.Length`](https://msdn.microsoft.com/en-us/library/system.collections.bitarray.length.aspx) getter.

This pull request contains a replacement of `BitArray.Count` with `BitArray.Length`.