### PR TITLE
Fix ignored `robust` param in MultipleLinearRegression.Regress

### DIFF
--- a/Sources/Accord.Statistics/Models/Regression/Linear/MultipleLinearRegression.cs
+++ b/Sources/Accord.Statistics/Models/Regression/Linear/MultipleLinearRegression.cs
@@ -172,7 +172,7 @@ namespace Accord.Statistics.Models.Regression.Linear
                 throw new ArgumentException("Number of input and output samples does not match", "outputs");
 
             double[,] design;
-            return regress(inputs, outputs, out design, true);
+            return regress(inputs, outputs, out design, robust);
         }
 
         /// <summary>


### PR DESCRIPTION
 MultipleLinearRegression.Regress(double[][], double[], bool) was ignoring last parameter instead of passing it further.