### PR TITLE
Fix Enumerator returned from KDTreeNodeCollection

### DIFF
--- a/Sources/Accord.MachineLearning/Collections/KDTreeNodeCollection.cs
+++ b/Sources/Accord.MachineLearning/Collections/KDTreeNodeCollection.cs
@@ -339,7 +339,7 @@ namespace Accord.Collections
         /// 
         public IEnumerator<NodeDistance<TNode>> GetEnumerator()
         {
-            for (int i = 0; i < positions.Length; i++)
+            for (int i = 0; i < count; i++)
                 yield return new NodeDistance<TNode>(positions[i], distances[i]);
 
             yield break;


### PR DESCRIPTION
Currently, the enumerator uses `position.Length` to determine how many items to iterate over.  This results in the enumerator returning objects that don't exist if the collection isn't full (as can happen when using `Nearest(location, radius, maxCount)` on a `KDTree`).

This fix changes the enumerator to use the already-existing `count` variable, which ought to prevent it from returning non-existent collection elements.