### PR TITLE
Added a check if matrix is rectangular before transposing

### DIFF
--- a/Sources/Accord.Math/Matrix/Jagged.Common.cs
+++ b/Sources/Accord.Math/Matrix/Jagged.Common.cs
@@ -69,6 +69,13 @@ namespace Accord.Math
             if (rows == 0) return new T[rows][];
             int cols = matrix[0].Length;
 
+            var isARectangularMatrix = IsRectangularMatrix(matrix);
+
+            if (!isARectangularMatrix)
+            {
+                throw new ArgumentException("Only rectangular matrices can be transposed.");
+            }
+
             if (inPlace)
             {
                 if (rows != cols)
@@ -98,6 +105,19 @@ namespace Accord.Math
 
                 return result;
             }
+        }
+
+        private static bool IsRectangularMatrix<T>(T[][] matrix)
+        {
+            var numberOfRows = matrix.Length;
+            var numberOfCols = matrix[0].Length;
+
+            for (int i = 1; i < numberOfRows; i++)
+            {
+                var length = matrix[i].Length;
+                if (length != numberOfCols) return false;
+            }
+            return true;
         }
 
 


### PR DESCRIPTION
I get some pretty unexpected results when trying to transpose a non-rectangular matrix; where the number of elements in each row aren't the same.