### PR TITLE
Update StochasticLayer.cs

### DIFF
--- a/Sources/Accord.Neuro/Layers/StochasticLayer.cs
+++ b/Sources/Accord.Neuro/Layers/StochasticLayer.cs
@@ -128,8 +128,8 @@ namespace Accord.Neuro.Layers
 
             for (int i = 0; i < neurons.Length; i++)
             {
-                sample[i] = neurons[i].Generate(input);
-                output[i] = neurons[i].Output;
+                output[i] = neurons[i].Compute(input);
+                sample[i] = neurons[i].Generate(output[i]);
             }
 
             this.sample = sample;


### PR DESCRIPTION
Neuron.Output property is not thread-safe.  Generate(double[] input) is more thread safe by only using Neuron.Compute and Neuron.Generate method outputs instead.