### PR TITLE
Updated nuspec files for FFMPEG so they no longer reference Accord.Core,

### DIFF
--- a/Setup/NuGet/Accord.Video.FFMPEG.nuspec
+++ b/Setup/NuGet/Accord.Video.FFMPEG.nuspec
@@ -18,7 +18,6 @@
     <tags>accord.net aforge.net framework ffmpeg video capture decode codec</tags>
     <dependencies>
       <dependency id="Accord"                 version="$version$" />
-      <dependency id="Accord.Core"            version="$version$" />
       <dependency id="Accord.Video"           version="$version$" />
     </dependencies>
   </metadata>

--- a/Setup/NuGet/Accord.Video.FFMPEG.x64.nuspec
+++ b/Setup/NuGet/Accord.Video.FFMPEG.x64.nuspec
@@ -18,7 +18,6 @@
     <tags>accord.net aforge.net framework ffmpeg video capture decode codec</tags>
     <dependencies>
       <dependency id="Accord"                 version="$version$" />
-      <dependency id="Accord.Core"            version="$version$" />
       <dependency id="Accord.Video"           version="$version$" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
which doesn't seem to exist.