### PR TITLE
ColorSlider component resource path's fix. fixes #604

### DIFF
--- a/Sources/Accord.Controls.Imaging/AForge/ColorSlider.cs
+++ b/Sources/Accord.Controls.Imaging/AForge/ColorSlider.cs
@@ -276,7 +276,7 @@ namespace Accord.Controls
 
             // load arrow bitmap
             Assembly assembly = this.GetType().Assembly;
-            arrow = new Bitmap(assembly.GetManifestResourceStream("Accord.Controls.Resources.arrow.bmp"));
+            arrow = new Bitmap(assembly.GetManifestResourceStream("Accord.Controls.AForge.Resources.arrow.bmp"));
             arrow.MakeTransparent(Color.FromArgb(255, 255, 255));
         }
 


### PR DESCRIPTION
ColorSlider constructor uses a string constant to access resources within folders. Error is fixed by following the project solution's folder structure.