### PR TITLE
Underlying stream doesn't close after serialization with GZip compression

### DIFF
--- a/Sources/Accord.Core/Serializer.cs
+++ b/Sources/Accord.Core/Serializer.cs
@@ -100,9 +100,9 @@ namespace Accord.IO
             if (compression == SerializerCompression.GZip)
             {
 #if NET35 || NET40
-                using (var gzip = new GZipStream(stream, CompressionMode.Compress))
+                using (var gzip = new GZipStream(stream, CompressionMode.Compress, leaveOpen: true))
 #else
-                using (var gzip = new GZipStream(stream, CompressionLevel.Optimal))
+                using (var gzip = new GZipStream(stream, CompressionLevel.Optimal, leaveOpen: true))
 #endif
                     new BinaryFormatter().Serialize(gzip, obj);
             }
@@ -346,7 +346,7 @@ namespace Accord.IO
                     object obj;
                     if (compression == SerializerCompression.GZip)
                     {
-                        using (var gzip = new GZipStream(stream, CompressionMode.Decompress))
+                        using (var gzip = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true))
                             obj = formatter.Deserialize(gzip);
                     }
                     else if (compression == SerializerCompression.None)

--- a/Unit Tests/Accord.Tests.Core/SerializerTest.cs
+++ b/Unit Tests/Accord.Tests.Core/SerializerTest.cs
@@ -20,10 +20,12 @@
 //    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //
 
+using System;
 using Accord.IO;
 using Accord.Math;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Accord.Tests
 {
@@ -151,6 +153,23 @@ namespace Accord.Tests
 
             foreach (int k in e.Keys)
                 Assert.AreEqual(e[k], a[k]);
+        }
+
+        [Test]
+        public void compression_test_stream()
+        {
+            using (var stream = new MemoryStream())
+            {
+                var e = new byte[] {1, 2, 3};
+                Serializer.Save(e, stream, compression: SerializerCompression.GZip);
+
+                stream.Position = 0;
+
+                byte[] a;
+                Serializer.Load(stream, out a, compression: SerializerCompression.GZip);
+
+                CollectionAssert.AreEqual(e, a);
+            }
         }
     }
 }


### PR DESCRIPTION
In this PR I fixed #673: explicitly set `leaveOpen` attribute for [GZipStream](https://msdn.microsoft.com/en-us/library/27ck2z1y(v=vs.90).aspx)  to `true`.