### PR TITLE
DoubleArrayChromosome CreateNew should honor Balancer properties

### DIFF
--- a/Sources/Accord.Genetic/Chromosomes/DoubleArrayChromosome.cs
+++ b/Sources/Accord.Genetic/Chromosomes/DoubleArrayChromosome.cs
@@ -284,7 +284,11 @@ namespace Accord.Genetic
         ///
         public override IChromosome CreateNew()
         {
-            return new DoubleArrayChromosome(chromosomeGenerator, mutationMultiplierGenerator, mutationAdditionGenerator, length);
+            var chromosome = new DoubleArrayChromosome(chromosomeGenerator, mutationMultiplierGenerator, mutationAdditionGenerator, length);
+            chromosome.CrossoverBalancer = this.CrossoverBalancer;
+            chromosome.MutationBalancer = this.MutationBalancer;
+
+            return chromosome;
         }
 
         /// <summary>


### PR DESCRIPTION
The existing function only copies over the generators that were originally set on the founding chromosomes constructor.  Its ignores the two "Balancer" properties that could have been set on the founding chromosome after construction.