### PR TITLE
DoubleArrayChromosome CreateNew should honor the Balancer properties …

### DIFF
--- a/Sources/Accord.Genetic/Chromosomes/DoubleArrayChromosome.cs
+++ b/Sources/Accord.Genetic/Chromosomes/DoubleArrayChromosome.cs
@@ -284,7 +284,11 @@ namespace Accord.Genetic
         ///
         public override IChromosome CreateNew()
         {
-            return new DoubleArrayChromosome(chromosomeGenerator, mutationMultiplierGenerator, mutationAdditionGenerator, length);
+            var chromosome = new DoubleArrayChromosome(chromosomeGenerator, mutationMultiplierGenerator, mutationAdditionGenerator, length);
+            chromosome.CrossoverBalancer = this.CrossoverBalancer;
+            chromosome.MutationBalancer = this.MutationBalancer;
+
+            return chromosome;
         }
 
         /// <summary>


### PR DESCRIPTION
DoubleArrayChromosome CreateNew should honor the Balancer properties of the founding chromosome