### PR TITLE
Update SequentialMinimalOptimizationRegression.cs

### DIFF
--- a/Sources/Extras/Accord.MachineLearning.GPL/SequentialMinimalOptimizationRegression.cs
+++ b/Sources/Extras/Accord.MachineLearning.GPL/SequentialMinimalOptimizationRegression.cs
@@ -342,6 +342,9 @@ namespace Accord.MachineLearning.VectorMachines.Learning
 
             // Initialize variables
             int N = Inputs.Length;
+            
+            // Set the value of the ε parameter controlled the width of the ε-insensitive zone
+            epsilon = Epsilon;
 
             // Lagrange multipliers
             this.alpha_a = new double[N];


### PR DESCRIPTION
This updates allows users to set a value of the **ε** parameter really. It has been tested using the **Regression (SVMs)** program from the samples. Without this changes it was impossible because the private variable **epsilon** of the **BaseSequentialMinimalOptimizationRegression** class used the fixed value **1e-3** and not changed whit changing the **Epsilon** property of the **BaseSupportVectorRegression** parent class.