### PR TITLE
GH-871: Bug in linear constraint gradient - vector has incorrect dimensions

### DIFF
--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/LinearConstraint.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/LinearConstraint.cs
@@ -348,13 +348,15 @@ namespace Accord.Math.Optimization
         {
             if (grad == null)
             {
-                grad = new double[x.Length];
+                var tmp = new double[x.Length];
 
                 for (int i = 0; i < indices.Length; i++)
                 {
                     int index = indices[i];
-                    grad[index] = CombinedAs[i];
+                    tmp[index] = CombinedAs[i];
                 }
+                
+                grad = tmp;
             }
 
             return grad;

--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/LinearConstraint.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/LinearConstraint.cs
@@ -66,7 +66,8 @@ namespace Accord.Math.Optimization
         public const double DefaultTolerance = 1e-12;
 
         private int[] indices;
-        private double[] scalars;
+        private double[] combinedAs;
+        private double[] grad;
 
         /// <summary>
         ///   Gets the number of variables in the constraint.
@@ -92,6 +93,7 @@ namespace Accord.Math.Optimization
                     throw new DimensionMismatchException("value");
 
                 this.indices = value;
+                this.grad = null;
             }
         }
 
@@ -101,7 +103,7 @@ namespace Accord.Math.Optimization
         /// </summary>
         public double[] CombinedAs
         {
-            get { return scalars; }
+            get { return combinedAs; }
             set
             {
                 if (value == null)
@@ -110,7 +112,8 @@ namespace Accord.Math.Optimization
                 if (value.Length != NumberOfVariables)
                     throw new DimensionMismatchException("value");
 
-                this.scalars = value;
+                this.combinedAs = value;
+                this.grad = null;
             }
         }
 
@@ -150,7 +153,7 @@ namespace Accord.Math.Optimization
         {
             this.NumberOfVariables = numberOfVariables;
             this.indices = Vector.Range(numberOfVariables);
-            this.scalars = Vector.Ones(numberOfVariables);
+            this.combinedAs = Vector.Ones(numberOfVariables);
             this.ShouldBe = ConstraintType.GreaterThanOrEqualTo;
 
             this.Function = compute;
@@ -244,15 +247,7 @@ namespace Accord.Math.Optimization
         /// 
         public double GetViolation(double[] input)
         {
-            double fx = 0;
-
-            for (int i = 0; i < indices.Length; i++)
-            {
-                double x = input[indices[i]];
-                double a = CombinedAs[i];
-
-                fx += x * a;
-            }
+            double fx = compute(input);
 
             switch (ShouldBe)
             {
@@ -351,7 +346,18 @@ namespace Accord.Math.Optimization
 
         private double[] gradient(double[] x)
         {
-            return CombinedAs;
+            if (grad == null)
+            {
+                grad = new double[x.Length];
+
+                for (int i = 0; i < indices.Length; i++)
+                {
+                    int index = indices[i];
+                    grad[index] = CombinedAs[i];
+                }
+            }
+
+            return grad;
         }
 
 

--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/LinearConstraint.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/LinearConstraint.cs
@@ -348,15 +348,23 @@ namespace Accord.Math.Optimization
         {
             if (grad == null)
             {
-                var tmp = new double[x.Length];
-
-                for (int i = 0; i < indices.Length; i++)
+                if (x.Length == indices.Length && indices.IsEqual(Vector.Range(x.Length)))
                 {
-                    int index = indices[i];
-                    tmp[index] = CombinedAs[i];
+                    grad = combinedAs;
+                }
+                else
+                {
+                    var tmp = new double[x.Length];
+
+                    for (int i = 0; i < indices.Length; i++)
+                    {
+                        int index = indices[i];
+                        tmp[index] = CombinedAs[i];
+                    }
+
+                    grad = tmp;
                 }
                 
-                grad = tmp;
             }
 
             return grad;

--- a/Unit Tests/Accord.Tests.Math/Optimization/LinearConstraintTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Optimization/LinearConstraintTest.cs
@@ -151,5 +151,81 @@ namespace Accord.Tests.Math
             }
         }
 
+        [Test]
+        public void TestGradientWithIndices()
+        {
+            // Arrange1
+            int[] indices1 = { 2, 4, 6 };
+            int[] indices2 = { 0, 4, 6 };
+            double[] combinedAs1 = { 2, 3, 4 };
+            double[] combinedAs2 = { 9, 5, 1 };
+            double[] x = Vector.Random(8);
+            double[] expected1 = { 0, 0, 2, 0, 3, 0, 4, 0 };
+            double[] expected2 = { 0, 0, 9, 0, 5, 0, 1, 0 };
+            double[] expected3 = { 9, 0, 0, 0, 5, 0, 1, 0 };
+
+            var linearConstraint = new LinearConstraint(indices1.Length)
+            {
+                CombinedAs = combinedAs1,
+                VariablesAtIndices = indices1,
+                ShouldBe = ConstraintType.EqualTo,
+                Value = 42
+            };
+
+            // Act1
+            double[] gradient = linearConstraint.Gradient(x);
+
+            // Assert1
+            Assert.True(gradient.IsEqual(expected1));
+
+            // Arrange2
+            linearConstraint.CombinedAs = combinedAs2;
+
+            // Act2
+            double[] gradient2 = linearConstraint.Gradient(x);
+
+            // Assert2
+            Assert.True(gradient2.IsEqual(expected2));
+
+            // Arrange3
+            linearConstraint.VariablesAtIndices = indices2;
+
+            // Act3
+            double[] gradient3 = linearConstraint.Gradient(x);
+
+            // Assert3
+            Assert.True(gradient3.IsEqual(expected3));
+        }
+
+        [Test]
+        public void TestGradientWithoutIndices()
+        {
+            // Arrange1
+            double[] combinedAs1 = { 2, 3, 4, 5, 6 };
+            double[] combinedAs2 = { 9, 5, 1, 5, 8 };
+            double[] x = Vector.Random(5);
+
+            var linearConstraint = new LinearConstraint(combinedAs1)
+            {
+                ShouldBe = ConstraintType.EqualTo,
+                Value = 42
+            };
+
+            // Act1
+            double[] gradient = linearConstraint.Gradient(x);
+
+            // Assert1
+            Assert.True(gradient.IsEqual(combinedAs1));
+
+            // Arrange2
+            linearConstraint.CombinedAs = combinedAs2;
+
+            // Act2
+            double[] gradient2 = linearConstraint.Gradient(x);
+
+            // Assert2
+            Assert.True(gradient2.IsEqual(combinedAs2));
+        }
+
     }
 }


### PR DESCRIPTION
Hi @cesarsouza,

Pull request to (partially) address the issue with the gradient being of incorrect size when indices are used. I know we spoke about the possibility of changing to use sparse and dense but, as a short-term fix I have simply implemented (a variation on) your proposal from earlier.

>  maybe one possibility to provide a correct, but still fast, version of the gradient method would be to cache the gradient vector after the first call to Gradient. The problem with that is that it wouldn't work in case the users modifies the vector referenced by the `CombinedAs` property directly, without using the property itself. 

I've gone for this but with a slight variation; if the indices are the default {0, 1, 2, 3, ..., n }, then I simply point to the `CombinedAs` vector. In this way, if the user modifies the `CombinedAs` vector directly, the gradient will reflect the change. 

As you note however, in the case where non-default indices are specified, it will still not work if someone subsequently mutates the underlying `CombinedAs` array elements. Of course, if they `set` the `CombinedAs` property then I clear the cached gradient and it will be fine. If you're not happy with this, then please let me know and we can simply recalculate the gradient every time (at the expense of speed).

As a longer term solution, I think it would be great to separate out the implementations of dense and sparse linear constraints and I would be happy to sketch out an API for this. As I mentioned before, I think this would make dense linear constraints much more performant and I can put together some benchmarks to show you what I mean if you like? It also feels a little counter-intuitive that the linear constraints store the indices as a memory-saving mechanism but then internally caches the full gradient.

### Unit tests
`TestGradientWithoutIndices` Test gradient without specifying indices
`TestGradientWithIndices` Test gradient specifying indices

Thanks,
Alex