### PR TITLE
GH-882: QR Decomposition not caching work intensive properties

### DIFF
--- a/Sources/Accord.Math/Decompositions/EigenvalueDecomposition.cs
+++ b/Sources/Accord.Math/Decompositions/EigenvalueDecomposition.cs
@@ -29,7 +29,6 @@ namespace Accord.Math.Decompositions
 {
     using System;
     using Accord.Math;
-    using Accord.Compat;
 
     /// <summary>
     ///     Determines the eigenvalues and eigenvectors of a real square matrix.
@@ -61,6 +60,9 @@ namespace Accord.Math.Decompositions
         private Double[] ort;       // storage for nonsymmetric algorithm.
         private bool symmetric;
 
+		private int? rank;
+		private Double[,] diagonalMatrix;
+
         private const Double eps = 2 * Constants.DoubleEpsilon;
         
 
@@ -74,13 +76,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 Double tol = n * d[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < d.Length; i++)
                     if (d[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -199,6 +204,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
                 var x = new Double[n, n];
 
                 for (int i = 0; i < n; i++)
@@ -217,7 +225,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.diagonalMatrix = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/EigenvalueDecomposition.tt
+++ b/Sources/Accord.Math/Decompositions/EigenvalueDecomposition.tt
@@ -78,6 +78,9 @@ namespace Accord.Math.Decompositions
         private <#=T#>[] ort;       // storage for nonsymmetric algorithm.
         private bool symmetric;
 
+		private int? rank;
+		private <#=T#>[,] diagonalMatrix;
+
         private const <#=T#> eps = 2 * Constants.<#=T#>Epsilon;
         
 
@@ -91,13 +94,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 <#=T#> tol = n * d[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < d.Length; i++)
                     if (d[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -216,6 +222,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
                 var x = new <#=T#>[n, n];
 
                 for (int i = 0; i < n; i++)
@@ -234,7 +243,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.diagonalMatrix = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/EigenvalueDecompositionF.cs
+++ b/Sources/Accord.Math/Decompositions/EigenvalueDecompositionF.cs
@@ -29,7 +29,6 @@ namespace Accord.Math.Decompositions
 {
     using System;
     using Accord.Math;
-    using Accord.Compat;
 
     /// <summary>
     ///     Determines the eigenvalues and eigenvectors of a real square matrix.
@@ -61,6 +60,9 @@ namespace Accord.Math.Decompositions
         private Single[] ort;       // storage for nonsymmetric algorithm.
         private bool symmetric;
 
+		private int? rank;
+		private Single[,] diagonalMatrix;
+
         private const Single eps = 2 * Constants.SingleEpsilon;
         
 
@@ -74,13 +76,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 Single tol = n * d[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < d.Length; i++)
                     if (d[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -199,6 +204,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
                 var x = new Single[n, n];
 
                 for (int i = 0; i < n; i++)
@@ -217,7 +225,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.diagonalMatrix = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/JaggedEigenvalueDecomposition.cs
+++ b/Sources/Accord.Math/Decompositions/JaggedEigenvalueDecomposition.cs
@@ -29,7 +29,6 @@ namespace Accord.Math.Decompositions
 {
     using System;
     using Accord.Math;
-    using Accord.Compat;
 
     /// <summary>
     ///     Determines the eigenvalues and eigenvectors of a real square matrix.
@@ -62,6 +61,9 @@ namespace Accord.Math.Decompositions
         private Double[] ort;       // storage for nonsymmetric algorithm.
         private bool symmetric;
 
+		private int? rank;
+		private Double[][] diagonalMatrix;
+
         private const Double eps = 2 * Constants.DoubleEpsilon;
 
 
@@ -75,13 +77,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 Double tol = n * d[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < d.Length; i++)
                     if (d[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -200,6 +205,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
                 var x = new Double[n][];
                 for (int i = 0; i < n; i++)
                   x[i] = new Double[n];
@@ -220,7 +228,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.diagonalMatrix = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/JaggedEigenvalueDecomposition.tt
+++ b/Sources/Accord.Math/Decompositions/JaggedEigenvalueDecomposition.tt
@@ -79,6 +79,9 @@ namespace Accord.Math.Decompositions
         private <#=T#>[] ort;       // storage for nonsymmetric algorithm.
         private bool symmetric;
 
+		private int? rank;
+		private <#=T#>[][] diagonalMatrix;
+
         private const <#=T#> eps = 2 * Constants.<#=T#>Epsilon;
 
 
@@ -92,13 +95,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 <#=T#> tol = n * d[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < d.Length; i++)
                     if (d[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -217,6 +223,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
                 var x = new <#=T#>[n][];
                 for (int i = 0; i < n; i++)
                   x[i] = new <#=T#>[n];
@@ -237,7 +246,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.diagonalMatrix = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/JaggedEigenvalueDecompositionF.cs
+++ b/Sources/Accord.Math/Decompositions/JaggedEigenvalueDecompositionF.cs
@@ -29,7 +29,6 @@ namespace Accord.Math.Decompositions
 {
     using System;
     using Accord.Math;
-    using Accord.Compat;
 
     /// <summary>
     ///     Determines the eigenvalues and eigenvectors of a real square matrix.
@@ -62,6 +61,9 @@ namespace Accord.Math.Decompositions
         private Single[] ort;       // storage for nonsymmetric algorithm.
         private bool symmetric;
 
+		private int? rank;
+		private Single[][] diagonalMatrix;
+
         private const Single eps = 2 * Constants.SingleEpsilon;
 
 
@@ -75,13 +77,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 Single tol = n * d[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < d.Length; i++)
                     if (d[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -200,6 +205,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
                 var x = new Single[n][];
                 for (int i = 0; i < n; i++)
                   x[i] = new Single[n];
@@ -220,7 +228,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.diagonalMatrix = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/JaggedQrDecomposition.cs
+++ b/Sources/Accord.Math/Decompositions/JaggedQrDecomposition.cs
@@ -29,7 +29,6 @@ namespace Accord.Math.Decompositions
 {
     using System;
     using Accord.Math;
-    using Accord.Compat;
 
     /// <summary>
     ///   QR decomposition for a rectangular matrix.
@@ -57,6 +56,11 @@ namespace Accord.Math.Decompositions
 
         private Double[][] qr;
         private Double[] Rdiag;
+
+		// cache for lazy evaluation
+        private bool? fullRank;
+        private Double[][] orthogonalFactor;
+        private Double[][] upperTriangularFactor;
 
         /// <summary>Constructs a QR decomposition.</summary>    
         /// <param name="value">The matrix A to be decomposed.</param>
@@ -315,10 +319,14 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.fullRank.HasValue)
+					return this.fullRank.Value;
+
                 for (int i = 0; i < p; i++)
                     if (this.Rdiag[i] == 0)
-                        return false;
-                return true;
+                        return (bool)(this.fullRank = false);
+
+                return (bool)(this.fullRank = true);
             }
         }
 
@@ -327,6 +335,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.upperTriangularFactor != null)
+					return this.upperTriangularFactor;
+
                 int rows = economy ? m : n;
                 var x = Jagged.Zeros<Double>(rows, p);
 
@@ -341,7 +352,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.upperTriangularFactor = x;
             }
         }
 
@@ -352,6 +363,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.orthogonalFactor != null)
+					return this.orthogonalFactor;
+
                 int cols = economy ? m : n;
                 var x = Jagged.Zeros<Double>(n, cols);
 
@@ -376,7 +390,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.orthogonalFactor = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/JaggedQrDecomposition.tt
+++ b/Sources/Accord.Math/Decompositions/JaggedQrDecomposition.tt
@@ -76,6 +76,11 @@ namespace Accord.Math.Decompositions
         private <#=T#>[][] qr;
         private <#=T#>[] Rdiag;
 
+		// cache for lazy evaluation
+        private bool? fullRank;
+        private <#=T#>[][] orthogonalFactor;
+        private <#=T#>[][] upperTriangularFactor;
+
         /// <summary>Constructs a QR decomposition.</summary>    
         /// <param name="value">The matrix A to be decomposed.</param>
         /// <param name="transpose">True if the decomposition should be performed on
@@ -333,10 +338,14 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.fullRank.HasValue)
+					return this.fullRank.Value;
+
                 for (int i = 0; i < p; i++)
                     if (this.Rdiag[i] == 0)
-                        return false;
-                return true;
+                        return (bool)(this.fullRank = false);
+
+                return (bool)(this.fullRank = true);
             }
         }
 
@@ -345,6 +354,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.upperTriangularFactor != null)
+					return this.upperTriangularFactor;
+
                 int rows = economy ? m : n;
                 var x = Jagged.Zeros<<#=T#>>(rows, p);
 
@@ -359,7 +371,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.upperTriangularFactor = x;
             }
         }
 
@@ -370,6 +382,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.orthogonalFactor != null)
+					return this.orthogonalFactor;
+
                 int cols = economy ? m : n;
                 var x = Jagged.Zeros<<#=T#>>(n, cols);
 
@@ -394,7 +409,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.orthogonalFactor = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/JaggedQrDecompositionD.cs
+++ b/Sources/Accord.Math/Decompositions/JaggedQrDecompositionD.cs
@@ -29,7 +29,6 @@ namespace Accord.Math.Decompositions
 {
     using System;
     using Accord.Math;
-    using Accord.Compat;
 
     /// <summary>
     ///   QR decomposition for a rectangular matrix.
@@ -57,6 +56,11 @@ namespace Accord.Math.Decompositions
 
         private Decimal[][] qr;
         private Decimal[] Rdiag;
+
+		// cache for lazy evaluation
+        private bool? fullRank;
+        private Decimal[][] orthogonalFactor;
+        private Decimal[][] upperTriangularFactor;
 
         /// <summary>Constructs a QR decomposition.</summary>    
         /// <param name="value">The matrix A to be decomposed.</param>
@@ -315,10 +319,14 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.fullRank.HasValue)
+					return this.fullRank.Value;
+
                 for (int i = 0; i < p; i++)
                     if (this.Rdiag[i] == 0)
-                        return false;
-                return true;
+                        return (bool)(this.fullRank = false);
+
+                return (bool)(this.fullRank = true);
             }
         }
 
@@ -327,6 +335,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.upperTriangularFactor != null)
+					return this.upperTriangularFactor;
+
                 int rows = economy ? m : n;
                 var x = Jagged.Zeros<Decimal>(rows, p);
 
@@ -341,7 +352,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.upperTriangularFactor = x;
             }
         }
 
@@ -352,6 +363,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.orthogonalFactor != null)
+					return this.orthogonalFactor;
+
                 int cols = economy ? m : n;
                 var x = Jagged.Zeros<Decimal>(n, cols);
 
@@ -376,7 +390,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.orthogonalFactor = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/JaggedQrDecompositionF.cs
+++ b/Sources/Accord.Math/Decompositions/JaggedQrDecompositionF.cs
@@ -29,7 +29,6 @@ namespace Accord.Math.Decompositions
 {
     using System;
     using Accord.Math;
-    using Accord.Compat;
 
     /// <summary>
     ///   QR decomposition for a rectangular matrix.
@@ -57,6 +56,11 @@ namespace Accord.Math.Decompositions
 
         private Single[][] qr;
         private Single[] Rdiag;
+
+		// cache for lazy evaluation
+        private bool? fullRank;
+        private Single[][] orthogonalFactor;
+        private Single[][] upperTriangularFactor;
 
         /// <summary>Constructs a QR decomposition.</summary>    
         /// <param name="value">The matrix A to be decomposed.</param>
@@ -315,10 +319,14 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.fullRank.HasValue)
+					return this.fullRank.Value;
+
                 for (int i = 0; i < p; i++)
                     if (this.Rdiag[i] == 0)
-                        return false;
-                return true;
+                        return (bool)(this.fullRank = false);
+
+                return (bool)(this.fullRank = true);
             }
         }
 
@@ -327,6 +335,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.upperTriangularFactor != null)
+					return this.upperTriangularFactor;
+
                 int rows = economy ? m : n;
                 var x = Jagged.Zeros<Single>(rows, p);
 
@@ -341,7 +352,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.upperTriangularFactor = x;
             }
         }
 
@@ -352,6 +363,9 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.orthogonalFactor != null)
+					return this.orthogonalFactor;
+
                 int cols = economy ? m : n;
                 var x = Jagged.Zeros<Single>(n, cols);
 
@@ -376,7 +390,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.orthogonalFactor = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/JaggedSingularValueDecomposition.cs
+++ b/Sources/Accord.Math/Decompositions/JaggedSingularValueDecomposition.cs
@@ -30,7 +30,9 @@ namespace Accord.Math.Decompositions
     using System;
     using Accord.Math;
 	using System.Diagnostics;
-    using Accord.Compat;
+#if NO_TRACE
+    using Trace = Accord.Diagnostics.Trace;
+#endif
 
     /// <summary>
     ///   Singular Value Decomposition for a rectangular matrix.
@@ -75,10 +77,13 @@ namespace Accord.Math.Decompositions
         private const Double eps = 2 * Constants.DoubleEpsilon;
         private const Double tiny = Constants.DoubleSmall;
 
-        Double? determinant;
+        int? rank;
+		Double? determinant;
         Double? lndeterminant;
         Double? pseudoDeterminant;
         Double? lnpseudoDeterminant;
+
+		Double[][] diagonalMatrix;
 
         /// <summary>
         ///   Returns the condition number <c>max(S) / min(S)</c>.
@@ -117,13 +122,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 Double tol = System.Math.Max(m, n) * s[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < s.Length; i++)
                     if (s[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -151,7 +159,13 @@ namespace Accord.Math.Decompositions
         ///
         public Double[][] DiagonalMatrix
         {
-            get { return Jagged.Diagonal(u[0].Length, v[0].Length, s); }
+            get 
+			{
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
+				return this.diagonalMatrix = Jagged.Diagonal(u[0].Length, v[0].Length, s); 
+			}
         }
 
         /// <summary>

--- a/Sources/Accord.Math/Decompositions/JaggedSingularValueDecomposition.tt
+++ b/Sources/Accord.Math/Decompositions/JaggedSingularValueDecomposition.tt
@@ -96,10 +96,13 @@ namespace Accord.Math.Decompositions
         private const <#=T#> eps = 2 * Constants.<#=T#>Epsilon;
         private const <#=T#> tiny = Constants.<#=T#>Small;
 
-        <#=T#>? determinant;
+        int? rank;
+		<#=T#>? determinant;
         <#=T#>? lndeterminant;
         <#=T#>? pseudoDeterminant;
         <#=T#>? lnpseudoDeterminant;
+
+		<#=T#>[][] diagonalMatrix;
 
         /// <summary>
         ///   Returns the condition number <c>max(S) / min(S)</c>.
@@ -138,13 +141,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 <#=T#> tol = System.Math.Max(m, n) * s[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < s.Length; i++)
                     if (s[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -172,7 +178,13 @@ namespace Accord.Math.Decompositions
         ///
         public <#=T#>[][] DiagonalMatrix
         {
-            get { return Jagged.Diagonal(u[0].Length, v[0].Length, s); }
+            get 
+			{
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
+				return this.diagonalMatrix = Jagged.Diagonal(u[0].Length, v[0].Length, s); 
+			}
         }
 
         /// <summary>

--- a/Sources/Accord.Math/Decompositions/JaggedSingularValueDecompositionD.cs
+++ b/Sources/Accord.Math/Decompositions/JaggedSingularValueDecompositionD.cs
@@ -30,7 +30,9 @@ namespace Accord.Math.Decompositions
     using System;
     using Accord.Math;
 	using System.Diagnostics;
-    using Accord.Compat;
+#if NO_TRACE
+    using Trace = Accord.Diagnostics.Trace;
+#endif
 
     /// <summary>
     ///   Singular Value Decomposition for a rectangular matrix.
@@ -75,10 +77,13 @@ namespace Accord.Math.Decompositions
         private const Decimal eps = 2 * Constants.DecimalEpsilon;
         private const Decimal tiny = Constants.DecimalSmall;
 
-        Decimal? determinant;
+        int? rank;
+		Decimal? determinant;
         Decimal? lndeterminant;
         Decimal? pseudoDeterminant;
         Decimal? lnpseudoDeterminant;
+
+		Decimal[][] diagonalMatrix;
 
         /// <summary>
         ///   Returns the condition number <c>max(S) / min(S)</c>.
@@ -117,13 +122,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 Decimal tol = System.Math.Max(m, n) * s[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < s.Length; i++)
                     if (s[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -151,7 +159,13 @@ namespace Accord.Math.Decompositions
         ///
         public Decimal[][] DiagonalMatrix
         {
-            get { return Jagged.Diagonal(u[0].Length, v[0].Length, s); }
+            get 
+			{
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
+				return this.diagonalMatrix = Jagged.Diagonal(u[0].Length, v[0].Length, s); 
+			}
         }
 
         /// <summary>

--- a/Sources/Accord.Math/Decompositions/JaggedSingularValueDecompositionF.cs
+++ b/Sources/Accord.Math/Decompositions/JaggedSingularValueDecompositionF.cs
@@ -30,7 +30,9 @@ namespace Accord.Math.Decompositions
     using System;
     using Accord.Math;
 	using System.Diagnostics;
-    using Accord.Compat;
+#if NO_TRACE
+    using Trace = Accord.Diagnostics.Trace;
+#endif
 
     /// <summary>
     ///   Singular Value Decomposition for a rectangular matrix.
@@ -75,10 +77,13 @@ namespace Accord.Math.Decompositions
         private const Single eps = 2 * Constants.SingleEpsilon;
         private const Single tiny = Constants.SingleSmall;
 
-        Single? determinant;
+        int? rank;
+		Single? determinant;
         Single? lndeterminant;
         Single? pseudoDeterminant;
         Single? lnpseudoDeterminant;
+
+		Single[][] diagonalMatrix;
 
         /// <summary>
         ///   Returns the condition number <c>max(S) / min(S)</c>.
@@ -117,13 +122,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 Single tol = System.Math.Max(m, n) * s[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < s.Length; i++)
                     if (s[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -151,7 +159,13 @@ namespace Accord.Math.Decompositions
         ///
         public Single[][] DiagonalMatrix
         {
-            get { return Jagged.Diagonal(u[0].Length, v[0].Length, s); }
+            get 
+			{
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
+				return this.diagonalMatrix = Jagged.Diagonal(u[0].Length, v[0].Length, s); 
+			}
         }
 
         /// <summary>

--- a/Sources/Accord.Math/Decompositions/QrDecomposition.cs
+++ b/Sources/Accord.Math/Decompositions/QrDecomposition.cs
@@ -57,10 +57,7 @@ namespace Accord.Math.Decompositions
         private Double[,] qr;
         private Double[] Rdiag;
 
-
 		// cache for lazy evaluation
-        // private Double? determinant;	// delete
-        // private double? lndeterminant;	// delete
         private bool? fullRank;
         private Double[,] orthogonalFactor;
         private Double[,] upperTriangularFactor;
@@ -309,19 +306,13 @@ namespace Accord.Math.Decompositions
             get
             {
 				if (this.fullRank.HasValue)
-				{
 					return this.fullRank.Value;
-				}
 
                 for (int i = 0; i < p; i++)
                     if (this.Rdiag[i] == 0)
-					{
-                        this.fullRank = false;
-						return false;
-					}
+						return (bool)(this.fullRank = false);
                 
-				this.fullRank = true;
-				return true;
+				return (bool)(this.fullRank = true);
             }
         }
 
@@ -331,9 +322,7 @@ namespace Accord.Math.Decompositions
             get
             {
 				if (this.upperTriangularFactor != null)
-				{
 					return this.upperTriangularFactor;
-				}
 
                 int rows = economy ? m : n;
                 var x = Matrix.Zeros<Double>(rows, p);
@@ -361,9 +350,7 @@ namespace Accord.Math.Decompositions
             get
             {
 				if (this.orthogonalFactor != null)
-				{
 					return this.orthogonalFactor;
-				}
 
                 int cols = economy ? m : n;
                 var x = Matrix.Zeros<Double>(n, cols);

--- a/Sources/Accord.Math/Decompositions/QrDecomposition.cs
+++ b/Sources/Accord.Math/Decompositions/QrDecomposition.cs
@@ -29,7 +29,6 @@ namespace Accord.Math.Decompositions
 {
     using System;
     using Accord.Math;
-    using Accord.Compat;
 
     /// <summary>
     ///      QR decomposition for a rectangular matrix.
@@ -57,6 +56,14 @@ namespace Accord.Math.Decompositions
 
         private Double[,] qr;
         private Double[] Rdiag;
+
+
+		// cache for lazy evaluation
+        // private Double? determinant;	// delete
+        // private double? lndeterminant;	// delete
+        private bool? fullRank;
+        private Double[,] orthogonalFactor;
+        private Double[,] upperTriangularFactor;
 
         /// <summary>Constructs a QR decomposition.</summary>    
         /// <param name="value">The matrix A to be decomposed.</param>
@@ -301,10 +308,20 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.fullRank.HasValue)
+				{
+					return this.fullRank.Value;
+				}
+
                 for (int i = 0; i < p; i++)
                     if (this.Rdiag[i] == 0)
-                        return false;
-                return true;
+					{
+                        this.fullRank = false;
+						return false;
+					}
+                
+				this.fullRank = true;
+				return true;
             }
         }
 
@@ -313,6 +330,11 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.upperTriangularFactor != null)
+				{
+					return this.upperTriangularFactor;
+				}
+
                 int rows = economy ? m : n;
                 var x = Matrix.Zeros<Double>(rows, p);
 
@@ -327,7 +349,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.upperTriangularFactor = x;
             }
         }
 
@@ -338,6 +360,11 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.orthogonalFactor != null)
+				{
+					return this.orthogonalFactor;
+				}
+
                 int cols = economy ? m : n;
                 var x = Matrix.Zeros<Double>(n, cols);
 
@@ -362,7 +389,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.orthogonalFactor = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/QrDecomposition.tt
+++ b/Sources/Accord.Math/Decompositions/QrDecomposition.tt
@@ -76,6 +76,14 @@ namespace Accord.Math.Decompositions
         private <#=T#>[,] qr;
         private <#=T#>[] Rdiag;
 
+
+		// cache for lazy evaluation
+        // private <#=T#>? determinant;	// delete
+        // private double? lndeterminant;	// delete
+        private bool? fullRank;
+        private <#=T#>[,] orthogonalFactor;
+        private <#=T#>[,] upperTriangularFactor;
+
         /// <summary>Constructs a QR decomposition.</summary>    
         /// <param name="value">The matrix A to be decomposed.</param>
         /// <param name="transpose">True if the decomposition should be performed on
@@ -319,10 +327,20 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.fullRank.HasValue)
+				{
+					return this.fullRank.Value;
+				}
+
                 for (int i = 0; i < p; i++)
                     if (this.Rdiag[i] == 0)
-                        return false;
-                return true;
+					{
+                        this.fullRank = false;
+						return false;
+					}
+                
+				this.fullRank = true;
+				return true;
             }
         }
 
@@ -331,6 +349,11 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.upperTriangularFactor != null)
+				{
+					return this.upperTriangularFactor;
+				}
+
                 int rows = economy ? m : n;
                 var x = Matrix.Zeros<<#=T#>>(rows, p);
 
@@ -345,7 +368,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.upperTriangularFactor = x;
             }
         }
 
@@ -356,6 +379,11 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.orthogonalFactor != null)
+				{
+					return this.orthogonalFactor;
+				}
+
                 int cols = economy ? m : n;
                 var x = Matrix.Zeros<<#=T#>>(n, cols);
 
@@ -380,7 +408,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.orthogonalFactor = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/QrDecomposition.tt
+++ b/Sources/Accord.Math/Decompositions/QrDecomposition.tt
@@ -76,10 +76,7 @@ namespace Accord.Math.Decompositions
         private <#=T#>[,] qr;
         private <#=T#>[] Rdiag;
 
-
 		// cache for lazy evaluation
-        // private <#=T#>? determinant;	// delete
-        // private double? lndeterminant;	// delete
         private bool? fullRank;
         private <#=T#>[,] orthogonalFactor;
         private <#=T#>[,] upperTriangularFactor;
@@ -328,19 +325,13 @@ namespace Accord.Math.Decompositions
             get
             {
 				if (this.fullRank.HasValue)
-				{
 					return this.fullRank.Value;
-				}
 
                 for (int i = 0; i < p; i++)
                     if (this.Rdiag[i] == 0)
-					{
-                        this.fullRank = false;
-						return false;
-					}
+						return (bool)(this.fullRank = false);
                 
-				this.fullRank = true;
-				return true;
+				return (bool)(this.fullRank = true);
             }
         }
 
@@ -350,9 +341,7 @@ namespace Accord.Math.Decompositions
             get
             {
 				if (this.upperTriangularFactor != null)
-				{
 					return this.upperTriangularFactor;
-				}
 
                 int rows = economy ? m : n;
                 var x = Matrix.Zeros<<#=T#>>(rows, p);
@@ -380,9 +369,7 @@ namespace Accord.Math.Decompositions
             get
             {
 				if (this.orthogonalFactor != null)
-				{
 					return this.orthogonalFactor;
-				}
 
                 int cols = economy ? m : n;
                 var x = Matrix.Zeros<<#=T#>>(n, cols);

--- a/Sources/Accord.Math/Decompositions/QrDecompositionD.cs
+++ b/Sources/Accord.Math/Decompositions/QrDecompositionD.cs
@@ -57,10 +57,7 @@ namespace Accord.Math.Decompositions
         private Decimal[,] qr;
         private Decimal[] Rdiag;
 
-
 		// cache for lazy evaluation
-        // private Decimal? determinant;	// delete
-        // private double? lndeterminant;	// delete
         private bool? fullRank;
         private Decimal[,] orthogonalFactor;
         private Decimal[,] upperTriangularFactor;
@@ -309,19 +306,13 @@ namespace Accord.Math.Decompositions
             get
             {
 				if (this.fullRank.HasValue)
-				{
 					return this.fullRank.Value;
-				}
 
                 for (int i = 0; i < p; i++)
                     if (this.Rdiag[i] == 0)
-					{
-                        this.fullRank = false;
-						return false;
-					}
+						return (bool)(this.fullRank = false);
                 
-				this.fullRank = true;
-				return true;
+				return (bool)(this.fullRank = true);
             }
         }
 
@@ -331,9 +322,7 @@ namespace Accord.Math.Decompositions
             get
             {
 				if (this.upperTriangularFactor != null)
-				{
 					return this.upperTriangularFactor;
-				}
 
                 int rows = economy ? m : n;
                 var x = Matrix.Zeros<Decimal>(rows, p);
@@ -361,9 +350,7 @@ namespace Accord.Math.Decompositions
             get
             {
 				if (this.orthogonalFactor != null)
-				{
 					return this.orthogonalFactor;
-				}
 
                 int cols = economy ? m : n;
                 var x = Matrix.Zeros<Decimal>(n, cols);

--- a/Sources/Accord.Math/Decompositions/QrDecompositionD.cs
+++ b/Sources/Accord.Math/Decompositions/QrDecompositionD.cs
@@ -29,7 +29,6 @@ namespace Accord.Math.Decompositions
 {
     using System;
     using Accord.Math;
-    using Accord.Compat;
 
     /// <summary>
     ///      QR decomposition for a rectangular matrix.
@@ -57,6 +56,14 @@ namespace Accord.Math.Decompositions
 
         private Decimal[,] qr;
         private Decimal[] Rdiag;
+
+
+		// cache for lazy evaluation
+        // private Decimal? determinant;	// delete
+        // private double? lndeterminant;	// delete
+        private bool? fullRank;
+        private Decimal[,] orthogonalFactor;
+        private Decimal[,] upperTriangularFactor;
 
         /// <summary>Constructs a QR decomposition.</summary>    
         /// <param name="value">The matrix A to be decomposed.</param>
@@ -301,10 +308,20 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.fullRank.HasValue)
+				{
+					return this.fullRank.Value;
+				}
+
                 for (int i = 0; i < p; i++)
                     if (this.Rdiag[i] == 0)
-                        return false;
-                return true;
+					{
+                        this.fullRank = false;
+						return false;
+					}
+                
+				this.fullRank = true;
+				return true;
             }
         }
 
@@ -313,6 +330,11 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.upperTriangularFactor != null)
+				{
+					return this.upperTriangularFactor;
+				}
+
                 int rows = economy ? m : n;
                 var x = Matrix.Zeros<Decimal>(rows, p);
 
@@ -327,7 +349,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.upperTriangularFactor = x;
             }
         }
 
@@ -338,6 +360,11 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.orthogonalFactor != null)
+				{
+					return this.orthogonalFactor;
+				}
+
                 int cols = economy ? m : n;
                 var x = Matrix.Zeros<Decimal>(n, cols);
 
@@ -362,7 +389,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.orthogonalFactor = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/QrDecompositionF.cs
+++ b/Sources/Accord.Math/Decompositions/QrDecompositionF.cs
@@ -29,7 +29,6 @@ namespace Accord.Math.Decompositions
 {
     using System;
     using Accord.Math;
-    using Accord.Compat;
 
     /// <summary>
     ///      QR decomposition for a rectangular matrix.
@@ -57,6 +56,14 @@ namespace Accord.Math.Decompositions
 
         private Single[,] qr;
         private Single[] Rdiag;
+
+
+		// cache for lazy evaluation
+        // private Single? determinant;	// delete
+        // private double? lndeterminant;	// delete
+        private bool? fullRank;
+        private Single[,] orthogonalFactor;
+        private Single[,] upperTriangularFactor;
 
         /// <summary>Constructs a QR decomposition.</summary>    
         /// <param name="value">The matrix A to be decomposed.</param>
@@ -301,10 +308,20 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.fullRank.HasValue)
+				{
+					return this.fullRank.Value;
+				}
+
                 for (int i = 0; i < p; i++)
                     if (this.Rdiag[i] == 0)
-                        return false;
-                return true;
+					{
+                        this.fullRank = false;
+						return false;
+					}
+                
+				this.fullRank = true;
+				return true;
             }
         }
 
@@ -313,6 +330,11 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.upperTriangularFactor != null)
+				{
+					return this.upperTriangularFactor;
+				}
+
                 int rows = economy ? m : n;
                 var x = Matrix.Zeros<Single>(rows, p);
 
@@ -327,7 +349,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.upperTriangularFactor = x;
             }
         }
 
@@ -338,6 +360,11 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.orthogonalFactor != null)
+				{
+					return this.orthogonalFactor;
+				}
+
                 int cols = economy ? m : n;
                 var x = Matrix.Zeros<Single>(n, cols);
 
@@ -362,7 +389,7 @@ namespace Accord.Math.Decompositions
                     }
                 }
 
-                return x;
+                return this.orthogonalFactor = x;
             }
         }
 

--- a/Sources/Accord.Math/Decompositions/QrDecompositionF.cs
+++ b/Sources/Accord.Math/Decompositions/QrDecompositionF.cs
@@ -57,10 +57,7 @@ namespace Accord.Math.Decompositions
         private Single[,] qr;
         private Single[] Rdiag;
 
-
 		// cache for lazy evaluation
-        // private Single? determinant;	// delete
-        // private double? lndeterminant;	// delete
         private bool? fullRank;
         private Single[,] orthogonalFactor;
         private Single[,] upperTriangularFactor;
@@ -309,19 +306,13 @@ namespace Accord.Math.Decompositions
             get
             {
 				if (this.fullRank.HasValue)
-				{
 					return this.fullRank.Value;
-				}
 
                 for (int i = 0; i < p; i++)
                     if (this.Rdiag[i] == 0)
-					{
-                        this.fullRank = false;
-						return false;
-					}
+						return (bool)(this.fullRank = false);
                 
-				this.fullRank = true;
-				return true;
+				return (bool)(this.fullRank = true);
             }
         }
 
@@ -331,9 +322,7 @@ namespace Accord.Math.Decompositions
             get
             {
 				if (this.upperTriangularFactor != null)
-				{
 					return this.upperTriangularFactor;
-				}
 
                 int rows = economy ? m : n;
                 var x = Matrix.Zeros<Single>(rows, p);
@@ -361,9 +350,7 @@ namespace Accord.Math.Decompositions
             get
             {
 				if (this.orthogonalFactor != null)
-				{
 					return this.orthogonalFactor;
-				}
 
                 int cols = economy ? m : n;
                 var x = Matrix.Zeros<Single>(n, cols);

--- a/Sources/Accord.Math/Decompositions/SingularValueDecomposition.cs
+++ b/Sources/Accord.Math/Decompositions/SingularValueDecomposition.cs
@@ -30,7 +30,9 @@ namespace Accord.Math.Decompositions
     using System;
     using Accord.Math;
 	using System.Diagnostics;
-    using Accord.Compat;
+#if NO_TRACE
+    using Trace = Accord.Diagnostics.Trace;
+#endif
 
     /// <summary>
     ///   Singular Value Decomposition for a rectangular matrix.
@@ -75,10 +77,13 @@ namespace Accord.Math.Decompositions
         private const Double eps = 2 * Constants.DoubleEpsilon;
         private const Double tiny = Constants.DoubleSmall;
 
-        Double? determinant;
+        int? rank;
+		Double? determinant;
         Double? lndeterminant;
         Double? pseudoDeterminant;
         Double? lnpseudoDeterminant;
+
+		Double[,] diagonalMatrix;
 
         /// <summary>
         ///   Returns the condition number <c>max(S) / min(S)</c>.
@@ -117,13 +122,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 Double tol = System.Math.Max(m, n) * s[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < s.Rows(); i++)
                     if (s[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -151,7 +159,13 @@ namespace Accord.Math.Decompositions
         ///
         public Double[,] DiagonalMatrix
         {
-            get { return Matrix.Diagonal(u.Columns(), v.Columns(), s); }
+            get 
+			{	
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
+				return diagonalMatrix = Matrix.Diagonal(u.Columns(), v.Columns(), s);
+			}
         }
 
         /// <summary>

--- a/Sources/Accord.Math/Decompositions/SingularValueDecomposition.tt
+++ b/Sources/Accord.Math/Decompositions/SingularValueDecomposition.tt
@@ -96,10 +96,13 @@ namespace Accord.Math.Decompositions
         private const <#=T#> eps = 2 * Constants.<#=T#>Epsilon;
         private const <#=T#> tiny = Constants.<#=T#>Small;
 
-        <#=T#>? determinant;
+        int? rank;
+		<#=T#>? determinant;
         <#=T#>? lndeterminant;
         <#=T#>? pseudoDeterminant;
         <#=T#>? lnpseudoDeterminant;
+
+		<#=T#>[,] diagonalMatrix;
 
         /// <summary>
         ///   Returns the condition number <c>max(S) / min(S)</c>.
@@ -138,13 +141,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 <#=T#> tol = System.Math.Max(m, n) * s[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < s.Rows(); i++)
                     if (s[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -172,7 +178,13 @@ namespace Accord.Math.Decompositions
         ///
         public <#=T#>[,] DiagonalMatrix
         {
-            get { return Matrix.Diagonal(u.Columns(), v.Columns(), s); }
+            get 
+			{	
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
+				return diagonalMatrix = Matrix.Diagonal(u.Columns(), v.Columns(), s);
+			}
         }
 
         /// <summary>

--- a/Sources/Accord.Math/Decompositions/SingularValueDecompositionD.cs
+++ b/Sources/Accord.Math/Decompositions/SingularValueDecompositionD.cs
@@ -30,7 +30,9 @@ namespace Accord.Math.Decompositions
     using System;
     using Accord.Math;
 	using System.Diagnostics;
-    using Accord.Compat;
+#if NO_TRACE
+    using Trace = Accord.Diagnostics.Trace;
+#endif
 
     /// <summary>
     ///   Singular Value Decomposition for a rectangular matrix.
@@ -75,10 +77,13 @@ namespace Accord.Math.Decompositions
         private const Decimal eps = 2 * Constants.DecimalEpsilon;
         private const Decimal tiny = Constants.DecimalSmall;
 
-        Decimal? determinant;
+        int? rank;
+		Decimal? determinant;
         Decimal? lndeterminant;
         Decimal? pseudoDeterminant;
         Decimal? lnpseudoDeterminant;
+
+		Decimal[,] diagonalMatrix;
 
         /// <summary>
         ///   Returns the condition number <c>max(S) / min(S)</c>.
@@ -117,13 +122,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 Decimal tol = System.Math.Max(m, n) * s[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < s.Rows(); i++)
                     if (s[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -151,7 +159,13 @@ namespace Accord.Math.Decompositions
         ///
         public Decimal[,] DiagonalMatrix
         {
-            get { return Matrix.Diagonal(u.Columns(), v.Columns(), s); }
+            get 
+			{	
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
+				return diagonalMatrix = Matrix.Diagonal(u.Columns(), v.Columns(), s);
+			}
         }
 
         /// <summary>

--- a/Sources/Accord.Math/Decompositions/SingularValueDecompositionF.cs
+++ b/Sources/Accord.Math/Decompositions/SingularValueDecompositionF.cs
@@ -30,7 +30,9 @@ namespace Accord.Math.Decompositions
     using System;
     using Accord.Math;
 	using System.Diagnostics;
-    using Accord.Compat;
+#if NO_TRACE
+    using Trace = Accord.Diagnostics.Trace;
+#endif
 
     /// <summary>
     ///   Singular Value Decomposition for a rectangular matrix.
@@ -75,10 +77,13 @@ namespace Accord.Math.Decompositions
         private const Single eps = 2 * Constants.SingleEpsilon;
         private const Single tiny = Constants.SingleSmall;
 
-        Single? determinant;
+        int? rank;
+		Single? determinant;
         Single? lndeterminant;
         Single? pseudoDeterminant;
         Single? lnpseudoDeterminant;
+
+		Single[,] diagonalMatrix;
 
         /// <summary>
         ///   Returns the condition number <c>max(S) / min(S)</c>.
@@ -117,13 +122,16 @@ namespace Accord.Math.Decompositions
         {
             get
             {
+				if (this.rank.HasValue)
+					return this.rank.Value;
+
                 Single tol = System.Math.Max(m, n) * s[0] * eps;
 
                 int r = 0;
                 for (int i = 0; i < s.Rows(); i++)
                     if (s[i] > tol) r++;
 
-                return r;
+                return (int)(this.rank = r);
             }
         }
 
@@ -151,7 +159,13 @@ namespace Accord.Math.Decompositions
         ///
         public Single[,] DiagonalMatrix
         {
-            get { return Matrix.Diagonal(u.Columns(), v.Columns(), s); }
+            get 
+			{	
+				if (this.diagonalMatrix != null)
+					return this.diagonalMatrix;
+
+				return diagonalMatrix = Matrix.Diagonal(u.Columns(), v.Columns(), s);
+			}
         }
 
         /// <summary>

--- a/Unit Tests/Accord.Tests.Math/Decompositions/EigenvalueDecompositionTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Decompositions/EigenvalueDecompositionTest.cs
@@ -89,6 +89,8 @@ namespace Accord.Tests.Math
 
             Assert.IsTrue(Matrix.IsEqual(expectedD, D, 0.00001));
             Assert.IsTrue(Matrix.IsEqual(A, actualA, 0.0001));
+
+            Assert.AreSame(target.DiagonalMatrix, target.DiagonalMatrix);
         }
 
 

--- a/Unit Tests/Accord.Tests.Math/Decompositions/JaggedEigenvalueDecompositionTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Decompositions/JaggedEigenvalueDecompositionTest.cs
@@ -87,6 +87,8 @@ namespace Accord.Tests.Math
 
             Assert.IsTrue(Matrix.IsEqual(expectedD, D, 0.00001));
             Assert.IsTrue(Matrix.IsEqual(A, actualA, 0.0001));
+
+            Assert.AreSame(target.DiagonalMatrix, target.DiagonalMatrix);
         }
 
 

--- a/Unit Tests/Accord.Tests.Math/Decompositions/JaggedQrDecompositionTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Decompositions/JaggedQrDecompositionTest.cs
@@ -115,6 +115,29 @@ namespace Accord.Tests.Math
         }
 
         [Test]
+        public void JaggedQrDecompositionCachingTest()
+        {
+            double[,] value =
+            {
+               {  2, -1,  0 },
+               { -1,  2, -1 },
+               {  0, -1,  2 }
+            };
+
+            var target = new JaggedQrDecomposition(value.ToJagged());
+
+            // Decomposition Identity
+            double[][] Q1 = target.OrthogonalFactor;
+            double[][] Q2 = target.OrthogonalFactor;
+
+            double[][] utf1 = target.UpperTriangularFactor;
+            double[][] utf2 = target.UpperTriangularFactor;
+
+            Assert.AreSame(Q1, Q2);
+            Assert.AreSame(utf1, utf2);
+        }
+
+        [Test]
         public void full_decomposition()
         {
             double[][] value =

--- a/Unit Tests/Accord.Tests.Math/Decompositions/JaggedSingularValueDecompositionTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Decompositions/JaggedSingularValueDecompositionTest.cs
@@ -425,6 +425,8 @@ namespace Accord.Tests.Math
             Assert.IsTrue(target1.DiagonalMatrix.IsEqual(target2.DiagonalMatrix));
             Assert.IsTrue(Matrix.IsEqual(value1, target1.Reverse(), 1e-2));
             Assert.IsTrue(Matrix.IsEqual(value2, target2.Reverse(), 1e-2));
+
+            Assert.AreSame(target1.DiagonalMatrix, target1.DiagonalMatrix);
         }
 
         [Test]

--- a/Unit Tests/Accord.Tests.Math/Decompositions/QrDecompositionTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Decompositions/QrDecompositionTest.cs
@@ -106,6 +106,29 @@ namespace Accord.Tests.Math
             Assert.IsTrue(Matrix.IsEqual(expected, actual, 0.0000000000001));
         }
 
+        [Test]
+        public void QrDecompositionCachingTest()
+        {
+            double[,] value =
+            {
+               {  2, -1,  0 },
+               { -1,  2, -1 },
+               {  0, -1,  2 }
+            };
+
+            var target = new QrDecomposition(value);
+
+            // Decomposition Identity
+            var Q1 = target.OrthogonalFactor;
+            var Q2 = target.OrthogonalFactor;
+
+            var utf1 = target.UpperTriangularFactor;
+            var utf2 = target.UpperTriangularFactor;
+
+            Assert.AreSame(Q1, Q2);
+            Assert.AreSame(utf1, utf2);
+        }
+
 
         [Test]
         public void InverseTest2()

--- a/Unit Tests/Accord.Tests.Math/Decompositions/QrDecompositionTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Decompositions/QrDecompositionTest.cs
@@ -93,7 +93,7 @@ namespace Accord.Tests.Math
 
             // Decomposition Identity
             var Q = target.OrthogonalFactor;
-            var QQt = Matrix.Multiply(Q, Q.Transpose());
+            var QQt = Q.DotWithTransposed(Q);
             Assert.IsTrue(Matrix.IsEqual(QQt, Matrix.Identity(3), 1e-6));
             Assert.IsTrue(Matrix.IsEqual(value, target.Reverse(), 1e-6));
 

--- a/Unit Tests/Accord.Tests.Math/Decompositions/SingularValueDecompositionTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Decompositions/SingularValueDecompositionTest.cs
@@ -426,6 +426,8 @@ namespace Accord.Tests.Math
 
             Assert.IsTrue(Matrix.IsEqual(target1.Reverse(), value1, 1e-5));
             Assert.IsTrue(Matrix.IsEqual(target2.Reverse(), value2, 1e-5));
+
+            Assert.AreSame(target1.DiagonalMatrix, target1.DiagonalMatrix);
         }
 
         [Test]


### PR DESCRIPTION
As discussed in #882:

> The LuDecomposition and CholeskyDecomposition classes expose properties with a simple Lazy evaluation pattern on the factored matrices. The QrDecomposition does not do this. Any unsuspecting user attempting to iterate through, say, the UpperTriangleFactor directly is in for a nasty shock as the matrix could potentially be rebuilt thousands of times.
> 
> Propose lazy cache on QR properties (or method call if caching undesirable). On phone but can post code snippet later if this is not clear. SVD has a few issues as well.

Fixed a few others and added checks in the unit test, `Assert.AreSame()` to check instance equality.

Thanks,
Alex

This closes #882 