### PR TITLE
GH-921: Fix for the normal random number generator when a seed is specified

### DIFF
--- a/Sources/Accord.Math/Random/ZigguratNormalGenerator.cs
+++ b/Sources/Accord.Math/Random/ZigguratNormalGenerator.cs
@@ -69,6 +69,11 @@ namespace Accord.Math.Random
         public ZigguratNormalGenerator(int seed)
         {
             u = new ZigguratUniformOneGenerator(seed);
+
+            kn = new uint[128];
+            fn = new double[128];
+            wn = new double[128];
+            setup();
         }
 
         /// <summary>
@@ -78,10 +83,6 @@ namespace Accord.Math.Random
         public ZigguratNormalGenerator()
             : this(Generator.Random.Next())
         {
-            kn = new uint[128];
-            fn = new double[128];
-            wn = new double[128];
-            setup();
         }
 
         /// <summary>

--- a/Unit Tests/Accord.Tests.Math/Accord.Tests.Math.csproj
+++ b/Unit Tests/Accord.Tests.Math/Accord.Tests.Math.csproj
@@ -139,6 +139,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Random\ZigguratNormalGeneratorTest.cs" />
     <Compile Include="Random\GeneratorTest.cs" />
     <Compile Include="ReducedRowEchelonFormTest.cs" />
     <Compile Include="Wavelets\CDF97Test.cs" />

--- a/Unit Tests/Accord.Tests.Math/Random/ZigguratNormalGeneratorTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Random/ZigguratNormalGeneratorTest.cs
@@ -1,0 +1,62 @@
+﻿// Accord Unit Tests
+// The Accord.NET Framework
+// http://accord-framework.net
+//
+// Copyright © César Souza, 2009-2017
+// cesarsouza at gmail.com
+//
+//    This library is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//
+//    This library is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public
+//    License along with this library; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+//
+
+namespace Accord.Tests.Math
+{
+    using System;
+    using Accord.Math.Optimization;
+    using NUnit.Framework;
+    using System.Threading.Tasks;
+    using System.Collections.Generic;
+    using Accord.Math;
+    using System.Threading;
+    using System.Collections.Concurrent;
+    using System.Linq;
+    using System.ComponentModel;
+    using Accord.Math.Random;
+
+    [TestFixture]
+    public class ZigguratNormalGeneratorTest
+    {
+
+        [Test]
+        public void TestZigguratNormalGenerator_InitializesCorrectly()
+        {
+            var rng = new ZigguratNormalGenerator();
+            double num = rng.Generate();
+
+            Assert.NotNull(rng);
+        }
+
+        [Test]
+        public void TestZigguratNormalGenerator_WithSeed_InitializesCorrectly()
+        {
+            var rng1 = new ZigguratNormalGenerator(seed: 5);
+            var rng2 = new ZigguratNormalGenerator(seed: 5);
+
+            double num1 = rng1.Generate();
+            double num2 = rng2.Generate();
+
+            Assert.AreEqual(num1, num2);
+        }
+    }
+}


### PR DESCRIPTION
Fix for GH-921. Simple fix where the logic to initialise the  `ZigguratNormalGenerator` internals are moved into the seeded constructor.

Unit tests in `ZigguratNormalGeneratorTest`