### PR TITLE
GH-818: Adding example of how to use a LinearConstraint

### DIFF
--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/LinearConstraint.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/LinearConstraint.cs
@@ -57,6 +57,21 @@ namespace Accord.Math.Optimization
     ///   Constraint with only linear terms.
     /// </summary>
     /// 
+    /// <example>
+    /// <para>
+    ///   Linear constraints are commonly used in optimisation routines.
+    ///   The framework provides support for linear constraints to be specified
+    ///   using a <see cref="string"/> representation, an <see cref="Expression"/> 
+    ///   or using a vector of constraint values.
+    /// </para>
+    /// 
+    /// <code source="Unit Tests\Accord.Tests.Math\Optimization\LinearConstraintTest.cs" region="doc_example" />
+    /// 
+    /// </example>
+    /// 
+    /// <seealso cref="LinearConstraintCollection"/>
+    ///
+
     public class LinearConstraint : IConstraint
     {
         /// <summary>

--- a/Unit Tests/Accord.Tests.Math/Optimization/LinearConstraintTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Optimization/LinearConstraintTest.cs
@@ -46,7 +46,50 @@ namespace Accord.Tests.Math
             }
         }
 
+        [Test]
+        public void DocumentationTest()
+        {
+            #region doc_example
+            // Linear constraints are common in numerical optimization.
+            // Constraints can be defined using strings, expressions or
+            // vectors. Suppose we have a quadratic objective function:
+            var f = new QuadraticObjectiveFunction("2x² + 4y² - 2xy + 6");
 
+            // Then the following three are all equivalent:
+            var lc1 = new LinearConstraint(f, "3*x + 5*y <= 7");
+
+            double x = 0, y = 0; // Define some dummy variables
+            var lc2 = new LinearConstraint(f, () => 3*x + 5*y <= 7);
+
+            var lc3 = new LinearConstraint(numberOfVariables: 2)
+            {
+                CombinedAs = new double[] { 3, 5 },
+                ShouldBe = ConstraintType.LesserThanOrEqualTo,
+                Value = 7
+            };
+
+            // Then, we can check whether a constraint is violated and, if so,
+            // by how much.
+            double[] vector = { -2, 3 };
+
+            if (lc1.IsViolated(vector))
+            {
+                // act on violation...
+            }
+
+            double violation = lc2.GetViolation(vector); // negative if violated
+
+            #endregion
+
+            double expected = -2;
+            double v1 = lc1.GetViolation(vector);
+            double v2 = lc2.GetViolation(vector);
+            double v3 = lc3.GetViolation(vector);
+
+            Assert.AreEqual(expected, v1);
+            Assert.AreEqual(expected, v2);
+            Assert.AreEqual(expected, v3);
+        }
 
         [Test]
         public void ConstructorTest1()


### PR DESCRIPTION
Adding documentation *as is*. Having discussed with you last week, changes to the `LinearConstraint` class are currently on hold (probably until an integer solver exists). I see no reason not to document the `LinearConstraint` in its current guise.

Thanks
A