### PR TITLE
GH-820: Augmented Lagrangian to support linear constraints

### DIFF
--- a/Sources/Accord.Math/Accord.Math.csproj
+++ b/Sources/Accord.Math/Accord.Math.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Matrix\Vector.MinMax.cs" />
     <Compile Include="Matrix\Matrix.MinMax.cs" />
     <Compile Include="Optimization\Base\IFunctionOptimizationMethod.cs" />
+    <Compile Include="Optimization\Constrained\Constraints\ConstraintExtensions.cs" />
     <Compile Include="Optimization\Losses\BinaryCrossEntropyLoss.cs" />
     <Compile Include="Optimization\Losses\CategoryCrossEntropyLoss.cs" />
     <Compile Include="Optimization\Losses\HammingLoss.cs" />

--- a/Sources/Accord.Math/Optimization/Constrained/AugmentedLagrangian.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/AugmentedLagrangian.cs
@@ -56,7 +56,7 @@ namespace Accord.Math.Optimization
 
         /// <summary>
         ///   The optimization could not make progress towards finding a feasible
-        ///   solution. Try increasing the <see cref="NonlinearConstraint.Tolerance"/>
+        ///   solution. Try increasing the <see cref="IConstraint.Tolerance"/>
         ///   of the constraints.
         /// </summary>
         /// 
@@ -115,9 +115,9 @@ namespace Accord.Math.Optimization
 
         IGradientOptimizationMethod dualSolver;
 
-        NonlinearConstraint[] lesserThanConstraints;
-        NonlinearConstraint[] greaterThanConstraints;
-        NonlinearConstraint[] equalityConstraints;
+        IConstraint[] lesserThanConstraints;
+        IConstraint[] greaterThanConstraints;
+        IConstraint[] equalityConstraints;
 
 
         private double rho;
@@ -206,9 +206,9 @@ namespace Accord.Math.Optimization
         /// 
         /// <param name="numberOfVariables">The number of free parameters in the optimization problem.</param>
         /// <param name="constraints">
-        ///   The <see cref="NonlinearConstraint"/>s to which the solution must be subjected.</param>
+        ///   The <see cref="IConstraint"/>s to which the solution must be subjected.</param>
         /// 
-        public AugmentedLagrangian(int numberOfVariables, IEnumerable<NonlinearConstraint> constraints)
+        public AugmentedLagrangian(int numberOfVariables, IEnumerable<IConstraint> constraints)
             : base(numberOfVariables)
         {
             init(null, constraints, null);
@@ -220,9 +220,9 @@ namespace Accord.Math.Optimization
         /// 
         /// <param name="function">The objective function to be optimized.</param>
         /// <param name="constraints">
-        ///   The <see cref="NonlinearConstraint"/>s to which the solution must be subjected.</param>
+        ///   The <see cref="IConstraint"/>s to which the solution must be subjected.</param>
         /// 
-        public AugmentedLagrangian(NonlinearObjectiveFunction function, IEnumerable<NonlinearConstraint> constraints)
+        public AugmentedLagrangian(NonlinearObjectiveFunction function, IEnumerable<IConstraint> constraints)
             : base(function.NumberOfVariables)
         {
             init(function, constraints, null);
@@ -237,10 +237,10 @@ namespace Accord.Math.Optimization
         ///   problem.</param>
         /// <param name="function">The objective function to be optimized.</param>
         /// <param name="constraints">
-        ///   The <see cref="NonlinearConstraint"/>s to which the solution must be subjected.</param>
+        ///   The <see cref="IConstraint"/>s to which the solution must be subjected.</param>
         /// 
         public AugmentedLagrangian(IGradientOptimizationMethod innerSolver,
-            NonlinearObjectiveFunction function, IEnumerable<NonlinearConstraint> constraints)
+            NonlinearObjectiveFunction function, IEnumerable<IConstraint> constraints)
             : base(innerSolver.NumberOfVariables)
         {
             if (innerSolver.NumberOfVariables != function.NumberOfVariables)
@@ -258,9 +258,9 @@ namespace Accord.Math.Optimization
         ///   optimization method</see> used internally to solve the dual of this optimization 
         ///   problem.</param>
         /// <param name="constraints">
-        ///   The <see cref="NonlinearConstraint"/>s to which the solution must be subjected.</param>
+        ///   The <see cref="IConstraint"/>s to which the solution must be subjected.</param>
         /// 
-        public AugmentedLagrangian(IGradientOptimizationMethod innerSolver, IEnumerable<NonlinearConstraint> constraints)
+        public AugmentedLagrangian(IGradientOptimizationMethod innerSolver, IEnumerable<IConstraint> constraints)
             : base(innerSolver.NumberOfVariables)
         {
             init(null, constraints, innerSolver);
@@ -268,7 +268,7 @@ namespace Accord.Math.Optimization
 
 
         private void init(NonlinearObjectiveFunction function,
-            IEnumerable<NonlinearConstraint> constraints, IGradientOptimizationMethod innerSolver)
+            IEnumerable<IConstraint> constraints, IGradientOptimizationMethod innerSolver)
         {
             if (function != null)
             {
@@ -294,9 +294,9 @@ namespace Accord.Math.Optimization
                 };
             }
 
-            var equality = new List<NonlinearConstraint>();
-            var lesserThan = new List<NonlinearConstraint>();
-            var greaterThan = new List<NonlinearConstraint>();
+            var equality = new List<IConstraint>();
+            var lesserThan = new List<IConstraint>();
+            var greaterThan = new List<IConstraint>();
 
             foreach (var c in constraints)
             {

--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/ConstraintExtensions.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/ConstraintExtensions.cs
@@ -1,0 +1,79 @@
+﻿// Accord Math Library
+// The Accord.NET Framework
+// http://accord-framework.net
+//
+// Copyright © César Souza, 2009-2017
+// cesarsouza at gmail.com
+//
+//    This library is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//
+//    This library is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public
+//    License along with this library; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+//
+
+namespace Accord.Math.Optimization
+{
+    using System;
+
+    /// <summary>
+    /// Extension methods on the <see cref="IConstraint"/> interface.
+    /// </summary>
+    public static class ConstraintExtensions
+    {
+
+        /// <summary>
+        ///   Gets how much the constraint is being violated.
+        /// </summary>
+        /// 
+        /// <param name="input">The function point.</param>
+        /// 
+        /// <returns>
+        ///   How much the constraint is being violated at the given point. Positive
+        ///   value means the constraint is not being violated with the returned slack, 
+        ///   while a negative value means the constraint is being violated by the returned
+        ///   amount.
+        /// </returns>
+        /// 
+        public static double GetViolation(this IConstraint constraint, double[] input)
+        {
+            double fx = constraint.Function(input);
+
+            switch (constraint.ShouldBe)
+            {
+                case ConstraintType.EqualTo:
+                    return Math.Abs(fx - constraint.Value);
+
+                case ConstraintType.GreaterThanOrEqualTo:
+                    return fx - constraint.Value;
+
+                case ConstraintType.LesserThanOrEqualTo:
+                    return constraint.Value - fx;
+            }
+
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Gets whether this constraint is being violated
+        /// (within the current tolerance threshold).
+        /// </summary>
+        /// <param name="constraint">The constraint.</param>
+        /// <param name="input">The function point.</param>
+        /// <returns>
+        /// True if the constraint is being violated, false otherwise.
+        /// </returns>
+        public static bool IsViolated(this IConstraint constraint, double[] input)
+        {
+            return constraint.GetViolation(input) + constraint.Tolerance < 0;
+        }
+    }
+}

--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/ConstraintExtensions.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/ConstraintExtensions.cs
@@ -31,18 +31,16 @@ namespace Accord.Math.Optimization
     {
 
         /// <summary>
-        ///   Gets how much the constraint is being violated.
+        /// Gets how much the constraint is being violated.
         /// </summary>
-        /// 
+        /// <param name="constraint">The constraint.</param>
         /// <param name="input">The function point.</param>
-        /// 
         /// <returns>
-        ///   How much the constraint is being violated at the given point. Positive
-        ///   value means the constraint is not being violated with the returned slack, 
-        ///   while a negative value means the constraint is being violated by the returned
-        ///   amount.
+        /// How much the constraint is being violated at the given point. Positive
+        /// value means the constraint is not being violated with the returned slack,
+        /// while a negative value means the constraint is being violated by the returned
+        /// amount.
         /// </returns>
-        /// 
         public static double GetViolation(this IConstraint constraint, double[] input)
         {
             double fx = constraint.Function(input);

--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/IConstraint.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/IConstraint.cs
@@ -24,6 +24,9 @@ namespace Accord.Math.Optimization
 {
     using System;
 
+    /// <summary>
+    /// Defines an interface for an optimization constraint.
+    /// </summary>
     public interface IConstraint
     {
         /// <summary>

--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/IConstraint.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/IConstraint.cs
@@ -22,8 +22,6 @@
 
 namespace Accord.Math.Optimization
 {
-    using System;
-
     /// <summary>
     /// Defines an interface for an optimization constraint.
     /// </summary>
@@ -55,17 +53,21 @@ namespace Accord.Math.Optimization
         int NumberOfVariables { get; }
 
         /// <summary>
-        ///   Gets the left hand side of 
-        ///   the constraint equation.
+        /// Calculates the left hand side of the constraint
+        /// equation given a vector x.
         /// </summary>
-        /// 
-        Func<double[], double> Function { get; }
+        /// <param name="x">The vector.</param>
+        /// <returns>
+        /// The left hand side of the constraint equation as evaluated at x.
+        /// </returns>
+        double Function(double[] x);
 
         /// <summary>
-        ///   Gets the gradient of the left hand
-        ///   side of the constraint equation.
+        /// Calculates the gradient of the constraint
+        /// equation given a vector x
         /// </summary>
-        /// 
-        Func<double[], double[]> Gradient { get; }
+        /// <param name="x">The vector.</param>
+        /// <returns>The gradient of the constraint as evaluated at x.</returns>
+        double[] Gradient(double[] x);
     }
 }

--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/IConstraint.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/IConstraint.cs
@@ -23,11 +23,8 @@
 namespace Accord.Math.Optimization
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
 
-    interface IConstraint
+    public interface IConstraint
     {
         /// <summary>
         ///   Gets the type of the constraint.
@@ -41,6 +38,12 @@ namespace Accord.Math.Optimization
         /// </summary>
         /// 
         double Value { get; }
+
+        /// <summary>
+        ///   Gets the violation tolerance for the constraint.
+        /// </summary>
+        /// 
+        double Tolerance { get; }
 
         /// <summary>
         ///   Gets the number of variables in the constraint.
@@ -61,20 +64,5 @@ namespace Accord.Math.Optimization
         /// </summary>
         /// 
         Func<double[], double[]> Gradient { get; }
-
-        /// <summary>
-        ///   Gets how much the constraint is being violated.
-        /// </summary>
-        /// 
-        /// <param name="input">The function point.</param>
-        /// 
-        /// <returns>
-        ///   How much the constraint is being violated at the given point. Positive
-        ///   value means the constraint is not being violated with the returned slack, 
-        ///   while a negative value means the constraint is being violated by the returned
-        ///   amount.
-        /// </returns>
-        /// 
-        double GetViolation(double[] input);
     }
 }

--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/LinearConstraint.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/LinearConstraint.cs
@@ -248,52 +248,6 @@ namespace Accord.Math.Optimization
         }
 
         /// <summary>
-        ///   Gets how much the constraint is being violated.
-        /// </summary>
-        /// 
-        /// <param name="input">The function point.</param>
-        /// 
-        /// <returns>
-        ///   How much the constraint is being violated at the given point. Positive
-        ///   value means the constraint is not being violated with the returned slack, 
-        ///   while a negative value means the constraint is being violated by the returned
-        ///   amount.
-        /// </returns>
-        /// 
-        public double GetViolation(double[] input)
-        {
-            double fx = compute(input);
-
-            switch (ShouldBe)
-            {
-                case ConstraintType.EqualTo:
-                    return Math.Abs(fx - Value);
-
-                case ConstraintType.GreaterThanOrEqualTo:
-                    return fx - Value;
-
-                case ConstraintType.LesserThanOrEqualTo:
-                    return Value - fx;
-            }
-
-            throw new NotSupportedException();
-        }
-
-        /// <summary>
-        ///   Gets whether this constraint is being violated 
-        ///   (within the current tolerance threshold).
-        /// </summary>
-        /// 
-        /// <param name="input">The function point.</param>
-        /// 
-        /// <returns>True if the constraint is being violated, false otherwise.</returns>
-        /// 
-        public bool IsViolated(double[] input)
-        {
-            return GetViolation(input) < -Tolerance;
-        }
-
-        /// <summary>
         ///   Attempts to create a <see cref="LinearConstraint"/>
         ///   from a <see cref="System.String"/> representation.
         /// </summary>

--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/LinearConstraint.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/LinearConstraint.cs
@@ -170,9 +170,6 @@ namespace Accord.Math.Optimization
             this.indices = Vector.Range(numberOfVariables);
             this.combinedAs = Vector.Ones(numberOfVariables);
             this.ShouldBe = ConstraintType.GreaterThanOrEqualTo;
-
-            this.Function = compute;
-            this.Gradient = gradient;
         }
 
         /// <summary>
@@ -189,9 +186,6 @@ namespace Accord.Math.Optimization
             this.indices = Vector.Range(0, coefficients.Length);
             this.CombinedAs = coefficients;
             this.ShouldBe = ConstraintType.GreaterThanOrEqualTo;
-
-            this.Function = compute;
-            this.Gradient = gradient;
         }
 
         /// <summary>
@@ -210,9 +204,6 @@ namespace Accord.Math.Optimization
             : this()
         {
             parseString(function, constraint, format);
-
-            this.Function = compute;
-            this.Gradient = gradient;
         }
 
         /// <summary>
@@ -242,9 +233,6 @@ namespace Accord.Math.Optimization
             : this()
         {
             parseExpression(function, constraint);
-
-            this.Function = compute;
-            this.Gradient = gradient;
         }
 
         /// <summary>
@@ -298,22 +286,36 @@ namespace Accord.Math.Optimization
             return true;
         }
 
-        private double compute(double[] input)
+        /// <summary>
+        /// Calculates the left hand side of the constraint
+        /// equation given a vector x.
+        /// </summary>
+        /// <param name="x">The vector.</param>
+        /// <returns>
+        /// The left hand side of the constraint equation as evaluated at x.
+        /// </returns>
+        public double Function(double[] x)
         {
             double sum = 0;
 
             for (int i = 0; i < indices.Length; i++)
             {
-                double x = input[indices[i]];
+                int index = indices[i];
+                double val = x[index];
                 double a = CombinedAs[i];
 
-                sum += x * a;
+                sum += val * a;
             }
 
             return sum;
         }
 
-        private double[] gradient(double[] x)
+        /// <summary>
+        /// Calculates the gradient of the constraint.
+        /// </summary>
+        /// <param name="x">The vector.</param>
+        /// <returns>The gradient of the constraint.</returns>
+        public double[] Gradient(double[] x)
         {
             if (grad == null)
             {
@@ -338,7 +340,6 @@ namespace Accord.Math.Optimization
 
             return grad;
         }
-
 
         private void parseString(IObjectiveFunction function, string constraint, CultureInfo culture)
         {
@@ -634,19 +635,5 @@ namespace Accord.Math.Optimization
 
             return null;
         }
-
-
-        /// <summary>
-        ///   Gets the left hand side of the constraint equation.
-        /// </summary>
-        /// 
-        public Func<double[], double> Function { get; private set; }
-
-        /// <summary>
-        ///   Gets the gradient of the left hand side of the constraint equation.
-        /// </summary>
-        /// 
-        public Func<double[], double[]> Gradient { get; private set; }
-
     }
 }

--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/NonlinearConstraint.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/NonlinearConstraint.cs
@@ -56,53 +56,7 @@ namespace Accord.Math.Optimization
         /// </summary>
         /// 
         public Func<double[], double[]> Gradient { get; private set; }
-
-        /// <summary>
-        ///   Gets how much the constraint is being violated.
-        /// </summary>
-        /// 
-        /// <param name="input">The function point.</param>
-        /// 
-        /// <returns>
-        ///   How much the constraint is being violated at the given point. Positive
-        ///   value means the constraint is not being violated with the returned slack, 
-        ///   while a negative value means the constraint is being violated by the returned
-        ///   amount.
-        /// </returns>
-        /// 
-        public double GetViolation(double[] input)
-        {
-            double fx = Function(input);
-
-            switch (ShouldBe)
-            {
-                case ConstraintType.EqualTo:
-                    return Math.Abs(fx - Value);
-
-                case ConstraintType.GreaterThanOrEqualTo:
-                    return fx - Value;
-
-                case ConstraintType.LesserThanOrEqualTo:
-                    return Value - fx;
-            }
-
-            throw new NotSupportedException();
-        }
-
-        /// <summary>
-        ///   Gets whether this constraint is being violated 
-        ///   (within the current tolerance threshold).
-        /// </summary>
-        /// 
-        /// <param name="input">The function point.</param>
-        /// 
-        /// <returns>True if the constraint is being violated, false otherwise.</returns>
-        /// 
-        public bool IsViolated(double[] input)
-        {
-            return GetViolation(input) < -Tolerance;
-        }
-
+        
         /// <summary>
         ///   Gets the type of the constraint.
         /// </summary>

--- a/Sources/Accord.Math/Optimization/Constrained/Constraints/NonlinearConstraint.cs
+++ b/Sources/Accord.Math/Optimization/Constrained/Constraints/NonlinearConstraint.cs
@@ -34,8 +34,11 @@ namespace Accord.Math.Optimization
     /// 
     public class NonlinearConstraint : IConstraint, IFormattable
     {
-
         private const double DEFAULT_TOL = 1e-8;
+
+        private Func<double[], double> function;
+
+        private Func<double[], double[]> gradient;
 
         /// <summary>
         ///   Gets the number of variables in the constraint.
@@ -43,20 +46,6 @@ namespace Accord.Math.Optimization
         /// 
         public int NumberOfVariables { get; private set; }
 
-        /// <summary>
-        ///   Gets the left hand side of 
-        ///   the constraint equation.
-        /// </summary>
-        /// 
-        public Func<double[], double> Function { get; private set; }
-
-        /// <summary>
-        ///   Gets the gradient of the left hand
-        ///   side of the constraint equation.
-        /// </summary>
-        /// 
-        public Func<double[], double[]> Gradient { get; private set; }
-        
         /// <summary>
         ///   Gets the type of the constraint.
         /// </summary>
@@ -102,14 +91,14 @@ namespace Accord.Math.Optimization
 
             // Generate lambda functions
             var func = ExpressionParser.Replace(function, objective.Variables);
-            this.Function = func.Compile();
+            this.function = func.Compile();
             this.Value = value;
             this.Tolerance = withinTolerance;
 
             if (gradient != null)
             {
                 var grad = ExpressionParser.Replace(gradient, objective.Variables);
-                this.Gradient = grad.Compile();
+                this.gradient = grad.Compile();
 
                 int n = NumberOfVariables;
                 double[] probe = new double[n];
@@ -226,6 +215,30 @@ namespace Accord.Math.Optimization
         }
 
         /// <summary>
+        /// Calculates the left hand side of the constraint
+        /// equation given a vector x.
+        /// </summary>
+        /// <param name="x">The vector.</param>
+        /// <returns>
+        /// The left hand side of the constraint equation as evaluated at x.
+        /// </returns>
+        public double Function(double[] x)
+        {
+            return this.function(x);
+        }
+
+        /// <summary>
+        /// Calculates the gradient of the constraint
+        /// equation given a vector x
+        /// </summary>
+        /// <param name="x">The vector.</param>
+        /// <returns>The gradient of the constraint as evaluated at x.</returns>
+        public double[] Gradient(double[] x)
+        {
+            return this.gradient(x);
+        }
+
+        /// <summary>
         ///    Creates a nonlinear constraint.
         /// </summary>
         /// 
@@ -249,10 +262,9 @@ namespace Accord.Math.Optimization
             this.Value = value;
             this.Tolerance = tolerance;
 
-            this.Function = function;
-            this.Gradient = gradient;
+            this.function = function;
+            this.gradient = gradient;
         }
-
 
 
         private static void parse(Expression<Func<double[], bool>> constraint,

--- a/Unit Tests/Accord.Tests.Math/Optimization/AugmentedLagrangianTest.cs
+++ b/Unit Tests/Accord.Tests.Math/Optimization/AugmentedLagrangianTest.cs
@@ -379,34 +379,19 @@ namespace Accord.Tests.Math
                 gradient: (x) => new[]
                 {
                     2 * (200 * Math.Pow(x[0], 3) - 200 * x[0] * x[1] + x[0] - 1), // df/dx = 2(200x³-200xy+x-1)
-                    200 * (x[1] - x[0]*x[0])                                   // df/dy = 200(y-x²)
+                    200 * (x[1] - x[0]*x[0])                                      // df/dy = 200(y-x²)
                 }
             );
 
-            // Now we can start stating the constraints
-            var constraints = new List<NonlinearConstraint>()
-            {
-                // Add the non-negativity constraint for x
-                new NonlinearConstraint(f,
-                    // 1st constraint: x should be greater than or equal to 0
-                    function: (x) => x[0], // x
-                    shouldBe: ConstraintType.GreaterThanOrEqualTo,
-                    value: 0,
-                    gradient: (x) => new[] { 1.0, 0.0 }
-                ),
-
-                // Add the non-negativity constraint for y
-                new NonlinearConstraint(f,
-                    // 2nd constraint: y should be greater than or equal to 0
-                    function: (x) => x[1], // y 
-                    shouldBe: ConstraintType.GreaterThanOrEqualTo,
-                    value: 0,
-                    gradient: (x) => new[] { 0.0, 1.0 }
-                )
-            };
+            // As before, we state the constraints. However, to illustrate the flexibility
+            // of the AugmentedLagrangian, we shall use LinearConstraints to constrain the problem.
+            double[,] a = Matrix.Identity(2); // Set up the constraint matrix...
+            double[] b = Vector.Zeros(2);     // ...and the values they must be greater than
+            int numberOfEqualities = 0;
+            var linearConstraints = LinearConstraintCollection.Create(a, b, numberOfEqualities);
 
             // Finally, we create the non-linear programming solver
-            var solver = new AugmentedLagrangian(f, constraints);
+            var solver = new AugmentedLagrangian(f, linearConstraints);
 
             // And attempt to find a minimum
             bool success = solver.Minimize();
@@ -423,9 +408,9 @@ namespace Accord.Tests.Math
             Assert.AreEqual(1, solver.Solution[0], 1e-6);
             Assert.AreEqual(1, solver.Solution[1], 1e-6);
 
-            Assert.IsFalse(Double.IsNaN(minValue));
-            Assert.IsFalse(Double.IsNaN(solver.Solution[0]));
-            Assert.IsFalse(Double.IsNaN(solver.Solution[1]));
+            Assert.IsFalse(double.IsNaN(minValue));
+            Assert.IsFalse(double.IsNaN(solver.Solution[0]));
+            Assert.IsFalse(double.IsNaN(solver.Solution[1]));
         }
 
         [Test]


### PR DESCRIPTION
Hi @cesarsouza,

Went for a fairly simple implementation in the end. I made a few design decisions along the way so if you don't want to go down this route, **please say and I'm 100% happy to change**.

Thanks,
Alex

## Changes
 - I changed all constructors from `IEnumerable<NonlinearConstraint>` to `IEnumerable<IConstraint>`. I don't believe (correct me if wrong) that this is a breaking change as long as you are using C# 4.0+ as `IEnumerable<>` became covariant in that release. It certainly didn't break any unit tests.
 - I had to change `IConstraint` from `internal` to `public` for access modifier consistency.
 - I had to add `Tolerance` to the interface of `IConstraint` so the `AugmentedLagrangian` could check it. However, I have *not* centralised any checking process on `Tolerance` as of yet so this might need to be a new issue in its own right. I'm happy to help out with the work but it might make sense for you to add the issue because I think you have something particular in mind (and I haven't fully understood the goal).
 - I removed `GetViolation()` from the `IConstraint` interface and added it as an extension method instead (as well as `IsViolated()`)
 - Promoted `Func<double[], double> Function { get; }` to `double Function(double[] x)` and similar for gradient.
 - documentation to give an example of using the linear constraint in the Augmented Lagrangian


Playing around with it, I really like the flexibility of `IEnumerable<IConstraint>` - users can now define their own constraints - and I think this is a good way to go. However, as the `IConstraint` interface is now exposed, it is one more thing that might break when integer programming is added so worth bearing in mind...