### PR TITLE
Addition of Vector Sampling with replacement?

### DIFF
--- a/Sources/Accord.Math/Vector/Vector.Random.cs
+++ b/Sources/Accord.Math/Vector/Vector.Random.cs
@@ -38,19 +38,20 @@ namespace Accord.Math
         }
 
         /// <summary>
-        ///   Draws a random sample from a group of observations, without repetitions.
+        ///   Draws a random sample from a group of observations, with or without repetitions.
         /// </summary>
         /// 
         /// <typeparam name="T">The type of the observations.</typeparam>
         /// 
         /// <param name="values">The observation vector.</param>
         /// <param name="size">The size of the sample to be drawn (how many samples to get).</param>
+        /// <param name="replacement">Whether to sample with replacement (repeating values) or without replacement (non-repeating values).</param>
         /// 
         /// <returns>A vector containing the samples drawn from <paramref name="values"/>.</returns>
         /// 
-        public static T[] Sample<T>(this T[] values, int size)
+        public static T[] Sample<T>(this T[] values, int size, bool replacement = false)
         {
-            int[] idx = Vector.Sample(size, values.Length);
+            int[] idx = replacement ? Vector.Random(size, 0, values.Length) : Vector.Sample(size, values.Length);            
             System.Diagnostics.Debug.Assert(idx.Length == size);
             return values.Get(idx);
         }


### PR DESCRIPTION
Is it ok to add support for Vector sampling with replacement (meaning: sampling from an array with repeating values)?

I have added an extra parameter in the method "T[] Sample<T>", the boolean "replacement" with a default value as false (in order not to affect the existing references that depend on it).

The motivation behind this, is to further support the random forest algorithm, with sampling with replacement:

"If the number of cases in the training set is N, sample N cases at random - but with replacement, from the original data." (Leo Breiman's original source: https://www.stat.berkeley.edu/~breiman/RandomForests/cc_home.htm#overview)