### PR TITLE
LevenbergMarquardt: implement the Marquardt contribution in the LevenbergMarquardt algorithm.

### DIFF
--- a/Sources/Accord.Math/Optimization/Unconstrained/Least Squares/LevenbergMarquardt.cs
+++ b/Sources/Accord.Math/Optimization/Unconstrained/Least Squares/LevenbergMarquardt.cs
@@ -354,7 +354,7 @@ namespace Accord.Math.Optimization
 
                 // Update diagonal (Levenberg-Marquardt)
                 for (int i = 0; i < diagonal.Length; i++)
-                    hessian[i][i] = diagonal[i] + 2 * lambda;
+                    hessian[i][i] = diagonal[i] * (1 + lambda);
 
 
                 // Decompose to solve the linear system. The Cholesky decomposition


### PR DESCRIPTION
Hi there, 

Thanks for this amazing library.

In the current implementation of the Levenberg-Marquardt algorithm, the approximation J^TJ of the Hessian matrix is damped using a \lambda * Identity factor. This is known as the Levenberg contribution, and the resulting algorithm is known as the Levenberg algorithm.

Marquardt contribution consists in damping J^TJ with \lambda * Diagonal, where Diagonal is the Diagonal of J^TJ. I think this factor should be implemented in the Levenberg-Marquardt algorithm.

Information regarding Levenberg and Marquardt contributions are available here : https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm

Moreover, using the Marquardt contribution instead of the Levenberg one has a real impact on the convergence of the algorithm: in particular, it allows the minimization to succeed even if the cost function is much smaller than one, where the current implementation fails.

Let me know if anything unclear,
Thanks,
Loïc