### PR TITLE
Fix dependencies of Accord.Audio.DirectSound.nuspec

### DIFF
--- a/Setup/NuGet/Accord.Audio.DirectSound.nuspec
+++ b/Setup/NuGet/Accord.Audio.DirectSound.nuspec
@@ -15,30 +15,28 @@
     <summary>Play and record audio using DirectSound.</summary>
     <tags>accord.net aforge.net framework computer audition audio processing wave capture</tags>
     <dependencies>
-      <group>
+      <group targetFramework="net35">
         <dependency id="Accord"               version="$version$" />
         <dependency id="Accord.Math"          version="$version$" />
         <dependency id="Accord.Audio"         version="$version$" />
-      </group>
-      <group targetFramework="net35">
-        <dependency id="SharpDX.DirectSound"  version="2.6.3" />
-      </group>
-      <group targetFramework="net40">
         <dependency id="SharpDX.DirectSound"  version="2.6.3" />
       </group>
       <group targetFramework="net45">
-        <dependency id="SharpDX.DirectSound"  version="4.0.1" />
-      </group>
-      <group targetFramework="net46">
-        <dependency id="SharpDX.DirectSound"  version="4.0.1" />
-      </group>
-      <group targetFramework="net462">
+        <dependency id="Accord"               version="$version$" />
+        <dependency id="Accord.Math"          version="$version$" />
+        <dependency id="Accord.Audio"         version="$version$" />
         <dependency id="SharpDX.DirectSound"  version="4.0.1" />
       </group>
       <group targetFramework="netstandard2.0">
+        <dependency id="Accord"               version="$version$" />
+        <dependency id="Accord.Math"          version="$version$" />
+        <dependency id="Accord.Audio"         version="$version$" />
         <dependency id="SharpDX.DirectSound"  version="4.0.1" />
       </group>
       <group targetFramework="netstandard1.4">
+        <dependency id="Accord"               version="$version$" />
+        <dependency id="Accord.Math"          version="$version$" />
+        <dependency id="Accord.Audio"         version="$version$" />
         <dependency id="SharpDX.DirectSound"  version="4.0.1" />
       </group>
     </dependencies>


### PR DESCRIPTION
When I install Accord.DirectSound 3.8.2-alpha package to .NET Framework 4.7 project, NuGet installs only the package itself and SharpDX (Figure 1). Other dependent packages, such as Accord.Math and Accord.Audio, are not to be installed.

So I fixed the nuspec file for NuGet to install all expected dependent packages.

![Figure 1](https://user-images.githubusercontent.com/1000655/36339938-5ef8946c-1413-11e8-8526-ec4aad3df1d2.png)
Figure 1

Figure 2 shows the packages that will be installed when I install the fixed package to .NET Framework 4.7 project. And Figure 3 shows when .NET Framework 4.0 project.

![Figure 2](https://user-images.githubusercontent.com/1000655/36339973-2e247576-1414-11e8-8df3-106e8f1b526d.png)
Figure 2

![Figure 3](https://user-images.githubusercontent.com/1000655/36339974-352c564a-1414-11e8-9984-717068606386.png)
Figure 3
