### PR TITLE
Fix ZhangSuenSkeletonization error

### DIFF
--- a/Sources/Accord.Imaging/AForge.Imaging/Filters/Other/ZhangSuenSkeletonization.cs
+++ b/Sources/Accord.Imaging/AForge.Imaging/Filters/Other/ZhangSuenSkeletonization.cs
@@ -150,7 +150,7 @@ namespace Accord.Imaging.Filters
 
             // do the job
             var dst0 = (byte*)destination.ImageData.ToPointer();
-            var del0 = stackalloc byte[delSize]; for (var i = 0; i < delSize; i++) del0[i] = 0xFF;
+            var del0 = (byte*)Marshal.AllocHGlobal(delSize).ToPointer();
 
             bool endOfAlgorithm;
 

--- a/Sources/Accord.Imaging/AForge.Imaging/Filters/Other/ZhangSuenSkeletonization.cs
+++ b/Sources/Accord.Imaging/AForge.Imaging/Filters/Other/ZhangSuenSkeletonization.cs
@@ -31,6 +31,7 @@ namespace Accord.Imaging.Filters
     using System.Collections.Generic;
     using System.Drawing;
     using System.Drawing.Imaging;
+    using System.Runtime.InteropServices;
 
     /// <summary>
     /// Zhang-Suen skeletonization filter.

--- a/Sources/Accord.Imaging/AForge.Imaging/Filters/Other/ZhangSuenSkeletonization.cs
+++ b/Sources/Accord.Imaging/AForge.Imaging/Filters/Other/ZhangSuenSkeletonization.cs
@@ -188,7 +188,7 @@ namespace Accord.Imaging.Filters
 
             } while (!endOfAlgorithm);
 			
-			// Free del memory
+            // Free del memory
             Marshal.FreeHGlobal(delPtr);
 
             #region Set colors

--- a/Sources/Accord.Imaging/AForge.Imaging/Filters/Other/ZhangSuenSkeletonization.cs
+++ b/Sources/Accord.Imaging/AForge.Imaging/Filters/Other/ZhangSuenSkeletonization.cs
@@ -151,7 +151,9 @@ namespace Accord.Imaging.Filters
 
             // do the job
             var dst0 = (byte*)destination.ImageData.ToPointer();
-            var del0 = (byte*)Marshal.AllocHGlobal(delSize).ToPointer();
+
+            var delPtr = Marshal.AllocHGlobal(delSize);
+            var del0 = (byte*)delPtr.ToPointer();
             for (var i = 0; i < delSize; i++) del0[i] = 0xFF;
 
             bool endOfAlgorithm;
@@ -185,6 +187,9 @@ namespace Accord.Imaging.Filters
                     del0);
 
             } while (!endOfAlgorithm);
+			
+			// Free del memory
+            Marshal.FreeHGlobal(delPtr);
 
             #region Set colors
 

--- a/Sources/Accord.Imaging/AForge.Imaging/Filters/Other/ZhangSuenSkeletonization.cs
+++ b/Sources/Accord.Imaging/AForge.Imaging/Filters/Other/ZhangSuenSkeletonization.cs
@@ -152,6 +152,7 @@ namespace Accord.Imaging.Filters
             // do the job
             var dst0 = (byte*)destination.ImageData.ToPointer();
             var del0 = (byte*)Marshal.AllocHGlobal(delSize).ToPointer();
+            for (var i = 0; i < delSize; i++) del0[i] = 0xFF;
 
             bool endOfAlgorithm;
 


### PR DESCRIPTION
Fix for bug [https://github.com/accord-net/framework/issues/1267](url)

## From report:
The **ZhangSuenSkeletonization** class will cause a **StackOverflowException** when running on large(ish) images
This is due to a byte array almost the size of the input image being allocated on the stack.
.NET applications have a default stack size limit of 1mb for 32bit applications and 4mb for 64 bit.
This results in 1026x1026 & 2050x2050 almost exceeding the maximum stack size

The fix is to change this: (line 153)
```C#
var del0 = stackalloc byte[delSize]; for (var i = 0; i < delSize; i++) del0[i] = 0xFF;
```
To this:
```C#
var del0 = (byte*)Marshal.AllocHGlobal(delSize).ToPointer();
```

From testing this does not incur any measurable time penalty