### PR TITLE
Random.Generator.Random returns null when ThreadSeed is set and then cleared

### DIFF
--- a/Sources/Accord.Math/Random/Generator.cs
+++ b/Sources/Accord.Math/Random/Generator.cs
@@ -170,6 +170,7 @@ namespace Accord.Math.Random
                 }
                 else
                 {
+                    Generator.threadOverriden = false;
                     Generator.threadRandom = null;
                 }
             }


### PR DESCRIPTION
In the current version of Math/Random/Generator.cs, there is no line to set Generator.threadOverriden to false. Thus once Generator.ThreadSeed is assigned to non-null and threadOverriden is set to true, Generator.Random will return threadRandom permanently. By re-assigning ThreadSeed to null, threadRandom becomes null. As a result, Generator.Random returns null.

This pr will address this issue by resetting threadOverriden to false when ThreadSeed is cleared.

Personally I'm not sure whether threadOverriden is necessary in addition to threadRandom, but it is a matter of refactoring anyway.