### PR TITLE
fixes #1404

### DIFF
--- a/Sources/Accord.MachineLearning/Clustering/MeanShift/MeanShiftCluster.cs
+++ b/Sources/Accord.MachineLearning/Clustering/MeanShift/MeanShiftCluster.cs
@@ -128,11 +128,7 @@ namespace Accord.MachineLearning
                     return acc + weights[i] * distance;
                 },
 
-                acc =>
-                {
-                    lock (labels)
-                        error += acc;
-                });
+                acc => { error += acc; });
 
             return error / weights.Sum();
         }


### PR DESCRIPTION
Hello,

I just fixed #1404 by removing the lock statement. The `lock` statement in there was to provide thread synchonization on `labels` variable, but there were no mutation in the statement, so it was unnecessary.