### PR TITLE
Fix off-by-one error in Matrix.GetSymmetric

### DIFF
--- a/Sources/Accord.Math/Matrix/Matrix.Common.cs
+++ b/Sources/Accord.Math/Matrix/Matrix.Common.cs
@@ -1077,7 +1077,7 @@ namespace Accord.Math
                     break;
                 case MatrixType.UpperTriangular:
                     for (int i = 0; i < matrix.Rows(); i++)
-                        for (int j = i; j <= matrix.Columns(); j++)
+                        for (int j = i; j < matrix.Columns(); j++)
                             result[i, j] = result[j, i] = matrix[i, j];
                     break;
                 default:

--- a/Unit Tests/Accord.Tests.Math/Matrix/Matrix.Common.cs
+++ b/Unit Tests/Accord.Tests.Math/Matrix/Matrix.Common.cs
@@ -218,5 +218,25 @@ namespace Accord.Tests.Math
                 { 20,   31,  42,  53,  64 }, 
             }));
         }
+
+        [Test]
+        public void GetSymmetricTest()
+        {
+            int[,] m =
+            {
+                { 1, 2, 3 },
+                { 0, 1, 2 },
+                { 0, 0, 1 }
+            };
+
+            int[,] expected =
+            {
+                { 1, 2, 3 },
+                { 2, 1, 2 },
+                { 3, 2, 1 }
+            };
+
+            Assert.AreEqual(expected, m.GetSymmetric(MatrixType.UpperTriangular));
+        }
     }
 }


### PR DESCRIPTION
Accord.Math.Matrix.GetSymmetric() always raises IndexOutOfRangeException when used with MatrixType.UpperTriangular because of invalid loop exit condition. This pr will fix this issue.