### PR TITLE
Fix exception on Windows native memory calls under Linux

### DIFF
--- a/Sources/Accord.Core/AForge.Core/SystemTools.cs
+++ b/Sources/Accord.Core/AForge.Core/SystemTools.cs
@@ -93,7 +93,25 @@ namespace Accord
         /// 
         public static unsafe byte* CopyUnmanagedMemory(byte* dst, byte* src, int count)
         {
+#if NETSTANDARD
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return memcpy(dst, src, count);
+            }
+            else
+            {
+                // for other platforms: copy bytewise
+                byte* d = dst;
+                byte* s = src;
+                for (int i = 0; i < count; ++i, ++d, ++s)
+                {
+                    *d = *s;
+                }
+                return dst;
+            }
+#else
             return memcpy(dst, src, count);
+#endif
         }
 
         /// <summary>
@@ -127,7 +145,24 @@ namespace Accord
         /// 
         public static unsafe byte* SetUnmanagedMemory(byte* dst, int filler, int count)
         {
+#if NETSTANDARD
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return memset(dst, filler, count);
+            }
+            else
+            {
+                byte* d = dst;
+                byte f = (byte)filler;
+                for (int i = 0; i < count; ++i, ++d)
+                {
+                    *d = f;
+                }
+                return dst;
+            }
+#else
             return memset(dst, filler, count);
+#endif
         }
 
 


### PR DESCRIPTION
If running Accord.Imaging under Linux, every conversion of a bitmap to UnmanagedImage calls SetUnmanagedMemory and CopyUnmanagedMemory. Those functions call native Windows functions, thus causing an exception if running e.g. under Linux.
This is fixed by a managed implementation when running under a non-Windows OS. Feel free to replace this by a corresponding call to a Linux / MacOS function.