### PR TITLE
Fix VS FastUpToDate check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,6 +34,7 @@
 *.bat     diff
 *.svg     diff
 *.csproj  diff
+*.targets diff
 *.vcxproj diff
 *.cs      diff
 *.tt      diff

--- a/Setup/Scripts/Accord.targets
+++ b/Setup/Scripts/Accord.targets
@@ -2,7 +2,8 @@
   <ItemGroup Condition="'$(MSBuildThisFileDirectory)' != '' And HasTrailingSlash('$(MSBuildThisFileDirectory)')">
     <Content Include="$(MSBuildThisFileDirectory)Accord.dll.config">
       <Link>Accord.dll.config</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
     </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This makes Accord play nice with Visual Studio's [FastUpToDateCheck](https://github.com/dotnet/project-system/blob/master/docs/repo/up-to-date-check.md).

Right now, VS will always consider every project that references Accord as not up-to-date and will always rebuild it. This PR fixes that by not forcing a file copy (Accord.dll.config) if it's already up-to-date.

I also added `<Visible>false</Visible>` so the file doesn't show up in the solution explorer.