### PR TITLE
Hide native libs from solution explorer when installing Video.FFMPEG nuget package

### DIFF
--- a/Setup/Scripts/Accord.Video.FFMPEG.targets
+++ b/Setup/Scripts/Accord.Video.FFMPEG.targets
@@ -4,6 +4,7 @@
     <None Include="@(NativeLibs)">
       <Link>%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
     </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
It's annoying to see links to native libs in Visual Studio solution explorer after installing `Accord.Video.FFMPEG` nuget package.

![image](https://user-images.githubusercontent.com/22616990/70227090-09b0bc00-1763-11ea-82cf-f3a8d7769f09.png)

This PR hides link to native libs.