### PR TITLE
Support Non-Square Matrices

### DIFF
--- a/Sources/Accord.Math/Optimization/Munkres.cs
+++ b/Sources/Accord.Math/Optimization/Munkres.cs
@@ -543,7 +543,7 @@ namespace Accord.Math.Optimization
                 zeros.RemoveAll(x => x.Item1 == path_row_0);
 
                 // Update
-                for (int r = 0; r < rowCover.Length; r++)
+                for (int r = 0; r < Math.Min(costMatrix.Length, rowCover.Length); r++)
                 {
                     if (rowCover[r])
                         continue;


### PR DESCRIPTION
This line in code seems to yield index-out-of-range errors with rectangular matrices. By changing it to use `Min` of the rowCover or the costMatrix length, the errors are avoided.