### PR TITLE
Fix MatNode.GetValue for different type of array

### DIFF
--- a/Sources/Accord.Math/IO/Mat/MatNode.cs
+++ b/Sources/Accord.Math/IO/Mat/MatNode.cs
@@ -114,7 +114,7 @@ namespace Accord.IO
 
             if (typeof(T).IsArray)
             {
-                var targetType = typeof(T).DeclaringType;
+                var targetType = typeof(T).GetElementType();
                 Array src = Value as Array;
                 Array dst = Array.CreateInstance(targetType, dimensions);
 

--- a/Sources/Accord.Math/IO/Mat/MatNode.cs
+++ b/Sources/Accord.Math/IO/Mat/MatNode.cs
@@ -118,6 +118,9 @@ namespace Accord.IO
                 Array src = Value as Array;
                 Array dst = Array.CreateInstance(targetType, dimensions);
 
+                if (matReader.Transpose)
+                    dst = dst.Transpose();
+
                 foreach (int[] idx in src.GetIndices())
                     dst.SetValue(Convert.ChangeType(src.GetValue(idx), targetType), idx);
 


### PR DESCRIPTION
This PR fixes an issue that `MatNode.GetValue<T>()` raises ArgumentNullException when passed different type of array (e.g. `ValueType` is `long[,]` and call `GetValue<double[,]>()`).

[Type.GetElementType](https://docs.microsoft.com/en-us/dotnet/api/system.type.getelementtype?redirectedfrom=MSDN&view=netframework-4.8#System_Type_GetElementType) should be used to get the base type of array, so changed `DeclaringType` into `GetElementType`.
In addition fixed an issue by `autoTranspose`.