### PR TITLE
VideoFileWriterTest: get to pass

### DIFF
--- a/Sources/Extras/Accord.Tests.Video.FFMPEG/WriterTest.cs
+++ b/Sources/Extras/Accord.Tests.Video.FFMPEG/WriterTest.cs
@@ -171,7 +171,7 @@ namespace Accord.Tests.Video
         {
             var fileInput = new FileInfo(fireplace_mp4);
             var fileOutput = new FileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "fireplace_output.webm"));
-            reencode(fileInput, fileOutput, VideoCodec.Vp8, expectedFrameRate: 14.985014985014985d);
+            reencode(fileInput, fileOutput, VideoCodec.Vp8);
         }
 
         [Test]


### PR DESCRIPTION
Not sure if I'm missing something here, but the the input frame rate is 29.97 and there doesn't appear to be anything changing the frame rate, so the expected frame rate should still be 29.97.  

This test was failing when I ran all unit tests.  I don't think it shows up in the tests CI runs because it is a longer running test.
