### PR TITLE
Update VideoFileWriter.cpp

### DIFF
--- a/Sources/Extras/Accord.Video.FFMPEG.GPL/VideoFileWriter.cpp
+++ b/Sources/Extras/Accord.Video.FFMPEG.GPL/VideoFileWriter.cpp
@@ -759,7 +759,7 @@ namespace Accord {
                 }
 
                 if (timestamp >= TimeSpan::Zero)
-                    data->video_st.next_pts = TimeSpanToPTS(timestamp, data->video_st.st, data->video_st.enc);
+                    data->video_st.next_pts = TimeSpanToPTS(timestamp, data->video_st.st, data->video_st.enc)*0.5;
 
                 data->send_video_frame(&data->video_st, (uint64_t*)bitmapData->Scan0.ToPointer(), bitmapData->Stride);
             }


### PR DESCRIPTION
fixed #2138，when i set options 
``` C#
_videoWriter.VideoOptions["x264opts"] = "no-mbtree:sliced-threads:sync-lookahead=0";
```
like
[https://github.com/cesarsouza/screencast-capture](https://github.com/cesarsouza/screencast-capture)

the `pts_time` Shouldn't twice `dts_time`

